### PR TITLE
Docs/loading modules and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ HelloWorldModule.childRoutes = (store) => {
   // return Route Components
 };
 
-// See "Loading Async Data" section
+// See "Loading Data" section
 HelloWorldModule.loadModuleData = async ({ store, fetchClient }) => {
   // Async Requests on Module Load
 };
@@ -394,11 +394,11 @@ export default HelloWorldModule;
 ```
 
 **Contents**
-* [Loading Modules](#loadingmodules)
-* [Loading Async Data](#loadingasyncdata)
+* [Loading Modules](##loading-modules)
+* [Loading Async Data](#loading-async-data)
 * [Routing](#routing)
 * [State Management](#)
-* [App Configuration](#appconfiguration)
+* [App Configuration](#app-configuration)
 
 #### [Server](#-server)
 
@@ -425,11 +425,16 @@ Documentation Forthcoming
 
 ##### React Router Component
 
+> 👍 Most commonly used method to load Holocron Modules
+
+A parent Module may add the `ModuleRoute` routing component to the [`childRoutes` Module Lifecycle Hook](#routing) to load a child Module dynamically on the server or browser when matching a route path. Once the Module is loaded, it is injected as a JSX element into the `children` prop of the parent Module.
+
 ###### `ModuleRoute`
 
 Please see [`ModuleRoute`](https://github.com/americanexpress/holocron/tree/master/packages/holocron-module-route#-usage) in the Holocron Module Route API.
 
 ##### Dispatch and Render
+We may use the `holocronModule` Higher Order Component to dispatch Holocron Redux Actions. Using the `load` argument in `holocronModule` we dispatch `composeModules` to retrieve a child Module bundle (e.g. `mymodule.browser.js`) and pass React `props` to it. Once loaded, a parent Module may add the `RenderModule` React Component into their JSX to render loaded Holocron Modules.
 
 ###### `RenderModule`
 
@@ -443,14 +448,18 @@ Please see [`holocronModule`](https://github.com/americanexpress/holocron/blob/m
 
 Please see [`composeModules`](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md#composemodules) in the Holocron API.
 
-#### Loading Async Data
+#### Loading Data
 
-When [Holocron Modules](#modules) are composed and loaded on the Server or Client, the `loadModuleData` Module Lifecycle Hook is called to load any async requests.
+When [Holocron Modules](#modules) are composed and loaded on the Server and Client, the `loadModuleData` Module Lifecycle Hook is called to load any async requests.
 
 **Contents**
 * [`loadModuleData`](#loadmoduledata)
 
 ##### `loadModuleData`
+
+**Runs On**
+* ✅ Server
+* ✅ Browser
 
 **Shape**
 ```js
@@ -469,6 +478,7 @@ The `loadModuleData` Module Lifecycle Hook, is executed on the 1) Server and 2) 
 In practice, we may [`dispatch`](https://redux.js.org/api/store/#dispatchaction) Redux actions and make [`async/await`](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Async_await) requests to populate our Module's reducers before any React Components are rendered:
 
 ```js
+// Runs on both Server and Browser
 HelloWorldModule.loadModuleData = async ({ store, fetchClient }) => {
   store.dispatch({ type: 'LOADING_API' });
   const response = await fetchClient('https://api.example.com');
@@ -479,6 +489,8 @@ HelloWorldModule.loadModuleData = async ({ store, fetchClient }) => {
 
 **📘 More Information**
 * Example: [SSR Frank](./prod-sample/sample-modules/ssr-frank/0.0.0/src/components/SsrFrank.jsx)
+* Docs: [Redux Store](https://redux.js.org/api/store)
+* Docs: [ES6 Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
 
 #### Routing
 

--- a/README.md
+++ b/README.md
@@ -467,9 +467,7 @@ When [Holocron Modules](#modules) are composed and loaded on the Server and Clie
 
 **Shape**
 ```js
-HelloWorldModule.loadModuleData = async ({ store, fetchClient }) => {
-  await Promise.resolve();
-};
+HelloWorldModule.loadModuleData = async ({ store, fetchClient }) => {};
 ```
 
 **Arguments**

--- a/README.md
+++ b/README.md
@@ -413,7 +413,9 @@ Documentation Forthcoming
 
 #### Loading Modules
 
-[Holocron Modules](#modules) are loaded on 1) the server when serving the initial HTML and 2) in the Browser when the client JavaScript takes over and the [Single Page App](https://developer.mozilla.org/en-US/docs/Glossary/SPA) is initialized. Holocron Modules are loaded either when a path is matched to a URL using the [child routes configuration](#routing), or when a React component uses the [Holocron API](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md) to load and render a module.
+In both the Server and the Browser, the Holocron Modules loaded depends on which path is matched to a URL using the [child routes configuration](#routing), or when a React component uses the [Holocron API](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md).
+
+Both methods are described in the following.
 
 **Contents**
 * React Router Component

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Both methods are described in the following.
   * [`holocronModule`](#holocronmodule)
   * [`composeModules`](#composemodules)
 
-##### React Router Component
+##### Route Component
 
 > 👍 Most commonly used method to load Holocron Modules
 

--- a/README.md
+++ b/README.md
@@ -467,7 +467,9 @@ When [Holocron Modules](#modules) are composed and loaded on the Server and Clie
 
 **Shape**
 ```js
-HelloWorldModule.loadModuleData = async ({ store, fetchClient }) => {};
+HelloWorldModule.loadModuleData = async ({ store, fetchClient }) => {
+  await Promise.resolve();
+};
 ```
 
 **Arguments**

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ export default HelloWorldModule;
 ```
 
 **Contents**
-* [Loading Modules](##loading-modules)
+* [Loading Modules](#loading-modules)
 * [Loading Async Data](#loading-async-data)
 * [Routing](#routing)
 * [State Management](#)
@@ -431,22 +431,29 @@ A parent Module may add the `ModuleRoute` routing component to the [`childRoutes
 
 ###### `ModuleRoute`
 
+<!-- ONE-MARKDOWN:START url="https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md" selector="### `ModuleRoute`" -->
 Please see [`ModuleRoute`](https://github.com/americanexpress/holocron/tree/master/packages/holocron-module-route#-usage) in the Holocron Module Route API.
+<!-- ONE-MARKDOWN:END -->
 
 ##### Dispatch and Render
 We may use the `holocronModule` Higher Order Component to dispatch Holocron Redux Actions. Using the `load` argument in `holocronModule` we dispatch `composeModules` to retrieve a child Module bundle (e.g. `mymodule.browser.js`) and pass React `props` to it. Once loaded, a parent Module may add the `RenderModule` React Component into their JSX to render loaded Holocron Modules.
 
 ###### `RenderModule`
-
+<!-- ONE-MARKDOWN:START url="https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md" selector="### `RenderModule`" -->
 Please see [`RenderModule`](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md#rendermodule) in the Holocron API.
+<!-- ONE-MARKDOWN:END -->
 
 ###### `holocronModule`
 
-Please see [`holocronModule`](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md#holocronmodule) in the Holocron API
+<!-- ONE-MARKDOWN:START url="https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md" selector="### `holocronModule`" -->
+Please see [`holocronModule`](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md#holocronmodule) in the Holocron API.
+<!-- ONE-MARKDOWN:END -->
 
 ###### `composeModules`
 
+<!-- ONE-MARKDOWN:START url="https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md" selector="### Compose Modules" -->
 Please see [`composeModules`](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md#composemodules) in the Holocron API.
+<!-- ONE-MARKDOWN:END -->
 
 #### Loading Data
 

--- a/README.md
+++ b/README.md
@@ -413,12 +413,12 @@ Documentation Forthcoming
 
 #### Loading Modules
 
-In both the Server and the Browser, the Holocron Modules loaded depends on which path is matched to a URL using the [child routes configuration](#routing), or when a React component uses the [Holocron API](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md).
+In either the Server or the Browser, there are two methods to select and load specific Holocron Modules: 1) Use Routes defined in the [child routes configuration](#routing) to match a URL path to a Holocron Module. 2) Or use dispatch-able methods in the [Holocron API](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md) to load Holocron Modules and render their contents with a React Component.
 
 Both methods are described in the following.
 
 **Contents**
-* React Router Component
+* Route Component
   * [`ModuleRoute`](#moduleroute)
 * Load and Render
   * [`RenderModule`](#rendermodule)
@@ -453,7 +453,7 @@ Please see [`composeModules`](https://github.com/americanexpress/holocron/blob/m
 
 #### Loading Data
 
-When [Holocron Modules](#modules) are composed and loaded on the Server and Client, the `loadModuleData` Module Lifecycle Hook is called to load any async requests. The `fetchClient` injected into the `loadModuleData` Hook may be customized using [`createSsrFetch`](#createssrfetch).
+When [Holocron Modules](#modules) are composed and loaded on the Server and Client, the `loadModuleData` Module Lifecycle Hook is called to load any async requests. On the Server only, the `fetchClient` injected into the `loadModuleData` Hook may be customized using [`createSsrFetch`](#createssrfetch).
 
 **Contents**
 * [`loadModuleData`](#loadmoduledata)

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ export default HelloWorldModule;
 
 **Contents**
 * [Loading Modules](#loading-modules)
-* [Loading Async Data](#loading-async-data)
+* [Loading Data](#loading-data)
 * [Routing](#routing)
 * [State Management](#)
 * [App Configuration](#app-configuration)
@@ -413,7 +413,7 @@ Documentation Forthcoming
 
 #### Loading Modules
 
-[Holocron Modules](#modules) are loaded and composed on 1) the Server when serving the HTML document and 2) in the Browser [Single Page App](https://developer.mozilla.org/en-US/docs/Glossary/SPA) mode via AJAX. We may load Holocron Modules when 1) a path is matched to the URL, or 2) dispatching a Redux action using an HOC and rendering with a React Component.
+[Holocron Modules](#modules) are loaded on 1) the server when serving the initial HTML and 2) in the Browser when the client JavaScript takes over and the [Single Page App](https://developer.mozilla.org/en-US/docs/Glossary/SPA) is initialized. Holocron Modules are loaded either when a path is matched to a URL using the [child routes configuration](#routing), or when a React component uses the [Holocron API](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md) to load and render a module.
 
 **Contents**
 * React Router Component
@@ -431,36 +431,31 @@ A parent Module may add the `ModuleRoute` routing component to the [`childRoutes
 
 ###### `ModuleRoute`
 
-<!-- ONE-MARKDOWN:START url="https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md" selector="### `ModuleRoute`" -->
 Please see [`ModuleRoute`](https://github.com/americanexpress/holocron/tree/master/packages/holocron-module-route#-usage) in the Holocron Module Route API.
-<!-- ONE-MARKDOWN:END -->
 
 ##### Dispatch and Render
+
 We may use the `holocronModule` Higher Order Component to dispatch Holocron Redux Actions. Using the `load` argument in `holocronModule` we dispatch `composeModules` to retrieve a child Module bundle (e.g. `mymodule.browser.js`) and pass React `props` to it. Once loaded, a parent Module may add the `RenderModule` React Component into their JSX to render loaded Holocron Modules.
 
 ###### `RenderModule`
-<!-- ONE-MARKDOWN:START url="https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md" selector="### `RenderModule`" -->
+
 Please see [`RenderModule`](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md#rendermodule) in the Holocron API.
-<!-- ONE-MARKDOWN:END -->
 
 ###### `holocronModule`
 
-<!-- ONE-MARKDOWN:START url="https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md" selector="### `holocronModule`" -->
 Please see [`holocronModule`](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md#holocronmodule) in the Holocron API.
-<!-- ONE-MARKDOWN:END -->
 
 ###### `composeModules`
 
-<!-- ONE-MARKDOWN:START url="https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md" selector="### Compose Modules" -->
 Please see [`composeModules`](https://github.com/americanexpress/holocron/blob/master/packages/holocron/API.md#composemodules) in the Holocron API.
-<!-- ONE-MARKDOWN:END -->
 
 #### Loading Data
 
-When [Holocron Modules](#modules) are composed and loaded on the Server and Client, the `loadModuleData` Module Lifecycle Hook is called to load any async requests.
+When [Holocron Modules](#modules) are composed and loaded on the Server and Client, the `loadModuleData` Module Lifecycle Hook is called to load any async requests. The `fetchClient` injected into the `loadModuleData` Hook may be customized using [`createSsrFetch`](#createssrfetch).
 
 **Contents**
 * [`loadModuleData`](#loadmoduledata)
+* [`createSsrFetch`](#createssrfetch)
 
 ##### `loadModuleData`
 
@@ -496,8 +491,13 @@ HelloWorldModule.loadModuleData = async ({ store, fetchClient }) => {
 
 **📘 More Information**
 * Example: [SSR Frank](./prod-sample/sample-modules/ssr-frank/0.0.0/src/components/SsrFrank.jsx)
+* Customize SSR Fetch Client: [`createSsrFetch`](#createssrfetch)
 * Docs: [Redux Store](https://redux.js.org/api/store)
 * Docs: [ES6 Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)
+
+##### `createSsrFetch`
+
+Please see [`createSsrFetch`](#createssrfetch-1) in the [App Configuration](#app-configuration) section.
 
 #### Routing
 
@@ -542,7 +542,7 @@ security and bundle size considerations.
 * [corsOrigins](#corsorigins)
 * [configureRequestLog](#configurerequestlog)
 * [extendSafeRequestRestrictedAttributes](#extendsaferequestrestrictedattributes)
-* [createSsrFetch](#createssrfetch)
+* [createSsrFetch](#createssrfetch-1)
 * [validateStateConfig](#validatestateconfig)
 * [requiredSafeRequestRestrictedAttributes](#requiredsaferequestrestrictedattributes)
 * [appCompatibility](#appcompatibility)
@@ -761,7 +761,7 @@ For example, you may wish to forward cookies or headers from the initial page lo
 **📘 More Information**
 * Example: [Frank Lloyd Root's `appConfig`](./prod-sample/sample-modules/frank-lloyd-root/0.0.0/src/config.js)
 * Example: [An SSR Fetch Client](./prod-sample/sample-modules/frank-lloyd-root/0.0.0/src/createFrankLikeFetch.js)
-* Using SSR Fetch Client with [`loadModuleData`](#loadModuleData)
+* Using SSR Fetch Client with [`loadModuleData`](#loadmoduledata)
 
 ##### `validateStateConfig`
 **Module Type**


### PR DESCRIPTION
- Implemented documentation on "Loading Modules" and "Loading Data" sections.
- Linked API docs in Holocron for methods that belong to holocron to prevent duplication of effort.
