### PR TITLE
docs(readme): add new quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Want to get paid for your contributions to `one-app`?
 * [Usage](#-usage)
 * [Recipes](#-recipes)
 * [API](#%EF%B8%8F-api)
-* [License](#-license)
-* [Code Of Conduct](#-code-of-conduct)
+* [License](#%EF%B8%8F-license)
+* [Code Of Conduct](#%EF%B8%8F-code-of-conduct)
 * [Contributing](#-contributing)
 
 ## ✨ Features
@@ -90,7 +90,7 @@ Paired with the built-in [one-app-dev-cdn](https://github.com/americanexpress/on
 
 #### Declare the module as your Root Module and start One App:
 
-Start up One App and declare your new module as the [Root Module](#-the-root-module):
+Start up One App and declare your new module as the [Root Module](#the-root-module):
 
 ```bash
 npm start -- --root-module-name=<module-name>
@@ -115,14 +115,14 @@ It is possible for your application to consist of only the root module, however 
 
 For a module to act as the root module the only requirements are:
 
-- Returns a React component bundled with [one-app-bundler](https://github.com/americanexpress/one-app-cli).
-- Provides a valid [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) though the [appConfig](#-configuration-with-app-config) static.
+- Returns a React component bundled with [one-app-bundler](https://github.com/americanexpress/one-app-cli/tree/master/packages/one-app-bundler).
+- Provides a valid [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) though the [appConfig](#app-configuration) static.
 
 **📘 More Information**
 * Root Module example: [frank-lloyd-root](https://github.com/americanexpress/one-app/blob/master/prod-sample/sample-modules/frank-lloyd-root/0.0.0/src/components/FrankLloydRoot.jsx)
-* [App Configuration in your Root Module](#-app-configuration)
-* [What are Holocron Modules?](#-modules)
-* [Useful Local Development Commands / Options](#-useful-local-development-commands-options)
+* [App Configuration in your Root Module](#app-configuration)
+* [What are Holocron Modules?](#modules)
+* [Useful Local Development Commands / Options](#useful-local-development-commands--options)
 
 
 ## 👩‍🍳 Recipes

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The easiest way to do this is via [npx](https://blog.npmjs.org/post/162869356040
 npx -p yo -p @americanexpress/generator-one-app-module -- yo one-app-module
 ```
 
-This will kick off the yeoman generator to scaffold your module.
+This will use the [One App Module Generator](https://github.com/americanexpress/one-app-cli/tree/master/packages/generator-one-app-module) to generate a basic One App module.
 
 **Clone and Install One App**
 
@@ -71,7 +71,7 @@ npm run serve-module <local-path-to-generated-module>
 # e.g. npm run serve-module ../my-first-module
 ```
 
-The `serve-module` command generates a `static` folder in the `one-app` root directory, containing a `module-map.json` and a `modules` folder with your bundled module code. Paired with the built-in [one-app-dev-cdn](https://github.com/americanexpress/one-app-dev-cdn) library, you're able to utilize [holocron]() while running your entire One App instance locally. No need to deploy and fetch remote assets from a CDN at this step.
+The `serve-module` command generates a `static` folder in the `one-app` root directory, containing a `module-map.json` and a `modules` folder with your bundled module code. Paired with the built-in [one-app-dev-cdn](https://github.com/americanexpress/one-app-dev-cdn) library, you're able to utilize the [Holocron Module Map](#-building-and-deploying-a-holocron-module-map) while running your entire One App instance locally. No need to deploy and fetch remote assets from a CDN at this step.
 
 **Declare the module as your Root Module and start One App:**
 
@@ -82,7 +82,7 @@ npm start -- --root-module-name=<module-name>
 # e.g. npm start -- --root-module-name=my-first-module
 ```
 
-This starts One App and makes it available at http://localhost:3000/success where you can see it in action! 
+This starts One App and makes it available at http://localhost:3000/ where you can see it in action! 
 
 Open another terminal window, run `npm run watch:build` in your module's directory and make some edits to the module. One App will pick up these changes and update the module bundles accordingly. When you reload your browser window, One App will be displaying your updated module.
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Want to get paid for your contributions to `one-app`?
 
 ### Quick Start
 
-**Build a Module with [generator-one-app-module](https://github.com/americanexpress/one-app-cli/tree/master/packages/generator-one-app-module)**
+#### Build a Module with [generator-one-app-module](https://github.com/americanexpress/one-app-cli/tree/master/packages/generator-one-app-module)
 
-The easiest way to do this is via [npx](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) (comes with `npm` versions 5.2.0 and above). Run the following command in the directory you want your module to live:
+The easiest way to do this is via [`npx`](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) (comes with `npm` versions 5.2.0 and above). Run the following command in the directory you want your module to live:
 
 ```bash
 npx -p yo -p @americanexpress/generator-one-app-module -- yo one-app-module
@@ -53,7 +53,7 @@ npx -p yo -p @americanexpress/generator-one-app-module -- yo one-app-module
 
 This will use the [One App Module Generator](https://github.com/americanexpress/one-app-cli/tree/master/packages/generator-one-app-module) to generate a basic One App module.
 
-**Clone and Install One App**
+#### Clone and Install One App
 
 ```bash
 export NODE_ENV=development
@@ -62,7 +62,7 @@ cd one-app
 npm ci --no-optional
 ```
 
-**Serve your Module to One App**
+#### Serve your Module to One App
 
 At the root of your `one-app` repo, run:
 
@@ -71,9 +71,24 @@ npm run serve-module <local-path-to-generated-module>
 # e.g. npm run serve-module ../my-first-module
 ```
 
-The `serve-module` command generates a `static` folder in the `one-app` root directory, containing a `module-map.json` and a `modules` folder with your bundled module code. Paired with the built-in [one-app-dev-cdn](https://github.com/americanexpress/one-app-dev-cdn) library, you're able to utilize the [Holocron Module Map](#-building-and-deploying-a-holocron-module-map) while running your entire One App instance locally. No need to deploy and fetch remote assets from a CDN at this step.
+The `serve-module` command generates a `static` folder in the `one-app` root directory, containing a `module-map.json` and a `modules` folder with your bundled module code: 
+```
+one-app/static
+├── module-map.json
+└── modules
+    └── my-first-module
+        └── 1.0.0
+            ├── my-first-module.browser.js
+            ├── my-first-module.browser.js.map
+            ├── my-first-module.legacy.browser.js
+            ├── my-first-module.legacy.browser.js.map
+            ├── my-first-module.node.js
+            └── my-first-module.node.js.map
+```
 
-**Declare the module as your Root Module and start One App:**
+Paired with the built-in [one-app-dev-cdn](https://github.com/americanexpress/one-app-dev-cdn) library, you're able to utilize the [Holocron Module Map](#-building-and-deploying-a-holocron-module-map) while running your entire One App instance locally. No need to deploy and fetch remote assets from a CDN at this step.
+
+#### Declare the module as your Root Module and start One App:
 
 Start up One App and declare your new module as the [Root Module](#-the-root-module):
 
@@ -96,12 +111,18 @@ The root module serves as the entry point for one-app to load an application.
           | ------------------------------- |
 ```
 
-It is possible for your application to consist of only the root module, however most application will want to take advantage of code splitting using [Holocron](https://github.com/americanexpress/holocron) and have the root module load other modules. More on this in [routing](#-routing).
+It is possible for your application to consist of only the root module, however most application will want to take advantage of code splitting using [Holocron](https://github.com/americanexpress/holocron) and have the root module load other modules. More on this in the [Routing](#-routing) section in the API docs.
 
 For a module to act as the root module the only requirements are:
 
 - Returns a React component bundled with [one-app-bundler](https://github.com/americanexpress/one-app-cli).
 - Provides a valid [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) though the [appConfig](#-configuration-with-app-config) static.
+
+**📘 More Information**
+* Root Module example: [frank-lloyd-root](https://github.com/americanexpress/one-app/blob/master/prod-sample/sample-modules/frank-lloyd-root/0.0.0/src/components/FrankLloydRoot.jsx)
+* [App Configuration in your Root Module](#-app-configuration)
+* [What are Holocron Modules?](#-modules)
+* [Useful Local Development Commands / Options](#-useful-local-development-commands-options)
 
 
 ## 👩‍🍳 Recipes

--- a/README.md
+++ b/README.md
@@ -43,7 +43,17 @@ Want to get paid for your contributions to `one-app`?
 
 ### Quick Start
 
-**Clone and Install One App:**
+**Build a Module with [generator-one-app-module](https://github.com/americanexpress/one-app-cli/tree/master/packages/generator-one-app-module)**
+
+The easiest way to do this is via [npx](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) (comes with `npm` versions 5.2.0 and above). Run the following command in the directory you want your module to live:
+
+```bash
+npx -p yo -p @americanexpress/generator-one-app-module -- yo one-app-module
+```
+
+This will kick off the yeoman generator to scaffold your module.
+
+**Clone and Install One App**
 
 ```bash
 export NODE_ENV=development
@@ -52,25 +62,29 @@ cd one-app
 npm ci --no-optional
 ```
 
-**Build a Module:**
+**Serve your Module to One App**
+
+At the root of your `one-app` repo, run:
 
 ```bash
-cd prod-sample/sample-modules/frank-lloyd-root/0.0.0
-npm ci
-cd ../../../..
-npm run serve-module prod-sample/sample-modules/frank-lloyd-root/0.0.0
-# this is used by the frank-lloyd-root module
-export ONE_CONFIG_ENV=development
+npm run serve-module <local-path-to-generated-module>
+# e.g. npm run serve-module ../my-first-module
 ```
 
-**Declare a Root Module and Start One App:**
+The `serve-module` command generates a `static` folder in the `one-app` root directory, containing a `module-map.json` and a `modules` folder with your bundled module code. Paired with the built-in [one-app-dev-cdn](https://github.com/americanexpress/one-app-dev-cdn) library, you're able to utilize [holocron]() while running your entire One App instance locally. No need to deploy and fetch remote assets from a CDN at this step.
+
+**Declare the module as your Root Module and start One App:**
+
+Start up One App and declare your new module as the [Root Module](#-the-root-module):
 
 ```bash
-npm start -- --root-module-name=frank-lloyd-root
+npm start -- --root-module-name=<module-name>
+# e.g. npm start -- --root-module-name=my-first-module
 ```
 
-This starts One App and makes it available at http://localhost:3000/success where you can see it in action!
+This starts One App and makes it available at http://localhost:3000/success where you can see it in action! 
 
+Open another terminal window, run `npm run watch:build` in your module's directory and make some edits to the module. One App will pick up these changes and update the module bundles accordingly. When you reload your browser window, One App will be displaying your updated module.
 
 ### The Root Module
 
@@ -82,7 +96,7 @@ The root module serves as the entry point for one-app to load an application.
           | ------------------------------- |
 ```
 
-It is possible for your application to consist of only the root module, however most application will want to take advantage of code splitting using [Holocron](https://github.com/americanexpress/holocron) and have the root module load other modules.
+It is possible for your application to consist of only the root module, however most application will want to take advantage of code splitting using [Holocron](https://github.com/americanexpress/holocron) and have the root module load other modules. More on this in [routing](#-routing).
 
 For a module to act as the root module the only requirements are:
 


### PR DESCRIPTION
Rather than use `frank-lloyd-root` in the quick start section, revised the section to use the new `generator-one-app-module` library to scaffold a custom root module so users better understand the process of creating and serving a module.