### PR TITLE
fix(utils): replace watchLocalModules cdn-url string to be ip/port

### DIFF
--- a/__tests__/server/utils/watchLocalModules.spec.js
+++ b/__tests__/server/utils/watchLocalModules.spec.js
@@ -28,7 +28,6 @@ import watchLocalModules from '../../../src/server/utils/watchLocalModules';
 
 const ip = address();
 
-
 jest.mock('chokidar', () => {
   const listeners = {};
   const watcher = () => null;

--- a/__tests__/server/utils/watchLocalModules.spec.js
+++ b/__tests__/server/utils/watchLocalModules.spec.js
@@ -23,7 +23,11 @@ import {
   getModules,
   resetModuleRegistry,
 } from 'holocron/moduleRegistry';
+import { address } from 'ip';
 import watchLocalModules from '../../../src/server/utils/watchLocalModules';
+
+const ip = address();
+
 
 jest.mock('chokidar', () => {
   const listeners = {};
@@ -64,6 +68,13 @@ jest.mock('fs', () => {
 
 describe('watchLocalModules', () => {
   beforeEach(() => jest.clearAllMocks());
+  let origOneAppDevCDNPort;
+  beforeAll(() => {
+    origOneAppDevCDNPort = process.env.HTTP_ONE_APP_DEV_CDN_PORT;
+  });
+  afterAll(() => {
+    process.env.HTTP_ONE_APP_DEV_CDN_PORT = origOneAppDevCDNPort;
+  });
 
   it('should watch the modules directory', () => {
     watchLocalModules();
@@ -128,5 +139,68 @@ describe('watchLocalModules', () => {
     const changeListener = chokidar.getListeners().change;
     await changeListener(changedPath);
     expect(loadModule).not.toHaveBeenCalled();
+  });
+
+  it('should replace [one-app-dev-cdn-url] with correct ip and port', async () => {
+    const moduleName = 'some-module';
+    const moduleVersion = '1.0.1';
+    process.env.HTTP_ONE_APP_DEV_CDN_PORT = 3002;
+    const moduleMapSample = {
+      key: '123',
+      modules: {
+        [moduleName]: {
+          node: {
+            integrity: '133',
+            url: `[one-app-dev-cdn-url]/cdn/${moduleName}/${moduleVersion}/${moduleName}-node.js`,
+          },
+          browser: {
+            integrity: '234',
+            url: `[one-app-dev-cdn-url]/cdn/${moduleName}/${moduleVersion}/${moduleName}-browser.js`,
+          },
+          legacyBrowser: {
+            integrity: '134633',
+            url: `[one-app-dev-cdn-url]/cdn/${moduleName}/${moduleVersion}/${moduleName}-legacy.browser.js`,
+          },
+        },
+      },
+    };
+    const oneAppDevCdnAddress = `http://${ip}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT || 3001}`;
+    const updatedModuleMapSample = {
+      key: '123',
+      modules: {
+        [moduleName]: {
+          node: {
+            integrity: '133',
+            url: `${oneAppDevCdnAddress}/cdn/${moduleName}/${moduleVersion}/${moduleName}-node.js`,
+          },
+          browser: {
+            integrity: '234',
+            url: `${oneAppDevCdnAddress}/cdn/${moduleName}/${moduleVersion}/${moduleName}-browser.js`,
+          },
+          legacyBrowser: {
+            integrity: '134633',
+            url: `${oneAppDevCdnAddress}/cdn/${moduleName}/${moduleVersion}/${moduleName}-legacy.browser.js`,
+          },
+        },
+      },
+    };
+    fs.readFileSync.mockImplementationOnce(() => JSON.stringify(moduleMapSample));
+    const modulePath = path.resolve(__dirname, `../../../static/modules/${moduleName}/${moduleVersion}/${moduleName}.node.js`);
+    const originalModule = () => null;
+    const updatedModule = () => null;
+    const modules = fromJS({ [moduleName]: originalModule });
+    const moduleMap = fromJS(moduleMapSample);
+    resetModuleRegistry(modules, moduleMap);
+    watchLocalModules();
+    const changeListener = chokidar.getListeners().change;
+    expect(getModules().get(moduleName)).toBe(originalModule);
+    loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
+    await changeListener(modulePath);
+    expect(loadModule).toHaveBeenCalledWith(
+      moduleName,
+      updatedModuleMapSample.modules[moduleName],
+      require('../../../src/server/utils/onModuleLoad').default
+    );
+    expect(getModules().get(moduleName)).toBe(updatedModule);
   });
 });

--- a/src/server/utils/watchLocalModules.js
+++ b/src/server/utils/watchLocalModules.js
@@ -26,7 +26,10 @@ import {
   getModuleMap,
   resetModuleRegistry,
 } from 'holocron/moduleRegistry';
+import { address } from 'ip';
 import onModuleLoad from './onModuleLoad';
+
+const ip = address();
 
 export default function watchLocalModules() {
   const staticsDirectoryPath = path.resolve(__dirname, '../../../static');
@@ -44,9 +47,16 @@ export default function watchLocalModules() {
 
     const moduleMap = JSON.parse(fs.readFileSync(moduleMapPath, 'utf8'));
 
+    const moduleData = moduleMap.modules[moduleNameChangeDetectedIn];
+    const oneAppDevCdnAddress = `http://${ip}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT || 3001}`;
+
+    moduleData.browser.url = moduleData.browser.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
+    moduleData.legacyBrowser.url = moduleData.legacyBrowser.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
+    moduleData.node.url = moduleData.node.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
+
     const module = await loadModule(
       moduleNameChangeDetectedIn,
-      moduleMap.modules[moduleNameChangeDetectedIn],
+      moduleData,
       onModuleLoad
     );
 


### PR DESCRIPTION
after generating a module, running `npm run watch:build` and serving it locally in One App, the follow error would appear:
```
log: Failed to load Holocron module at [one-app-dev-cdn-url]/static/modules/my-module/1.0.0/yeehaw.node.js
log: Error: only absolute urls are supported
```

this fix replaces the static [one-app-dev-cdn-url] string and replaces it with the actual ip and port when pulling from the module map. 

Note: The module still loaded successfully before this fix - this is specifically to mitigate the error in the console.