### PR TITLE
docs(readme): update generator command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Want to get paid for your contributions to `one-app`?
 The easiest way to do this is via [`npx`](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) (comes with `npm` versions 5.2.0 and above). Run the following command in the directory you want your module to live:
 
 ```bash
-npx -p yo -p @americanexpress/generator-one-app-module -- yo one-app-module
+npx -p yo -p @americanexpress/generator-one-app-module -- yo @americanexpress/one-app-module
 ```
 
 This will use the [One App Module Generator](https://github.com/americanexpress/one-app-cli/tree/master/packages/generator-one-app-module) to generate a basic One App module.


### PR DESCRIPTION
old npx command was faulty. The correct command (for our scoped library) is `npx -p yo -p @americanexpress/generator-one-app-module -- yo @americanexpress/one-app-module`