### PR TITLE
feat(csp): add local development domains to csp

### DIFF
--- a/__tests__/server/middleware/__snapshots__/csp.spec.js.snap
+++ b/__tests__/server/middleware/__snapshots__/csp.spec.js.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`csp middleware adds ip and localhost to csp in development 1`] = `"default-src 'none'; script-src 'nonce-00000000-0000-0000-0000-000000000000' 0.0.0.0:5000 localhost:5000 'self'; connect-src 0.0.0.0:5000 localhost:5000 'self';"`;
+
 exports[`csp updateCSP updates cspCache with given csp 1`] = `"default-src 'self';"`;

--- a/__tests__/server/middleware/csp.spec.js
+++ b/__tests__/server/middleware/csp.spec.js
@@ -99,9 +99,9 @@ describe('csp', () => {
       const headers = res._getHeaders();
       expect(headers).toHaveProperty('content-security-policy');
       const cspString = headers['content-security-policy'];
-      const ipFound = cspString.match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:3001/);
+      const ipFound = cspString.match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/);
       expect(ipFound).toBeNull();
-      const localhostFound = cspString.match(/localhost:3001/);
+      const localhostFound = cspString.match(/localhost/);
       expect(localhostFound).toBeNull();
     });
 

--- a/__tests__/server/middleware/csp.spec.js
+++ b/__tests__/server/middleware/csp.spec.js
@@ -16,6 +16,11 @@
 
 import httpMocks from 'node-mocks-http';
 
+const sanitizeCspString = (cspString) => cspString
+// replaces dynamic ip and nonce to prevent snapshot failures
+  .replace(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/g, '0.0.0.0')
+  .replace(/nonce-[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}/, 'nonce-00000000-0000-0000-0000-000000000000');
+
 describe('csp', () => {
   jest.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -48,7 +53,7 @@ describe('csp', () => {
     });
 
     it('sets a csp header in development', () => {
-      process.env.NODE_ENV = 'production';
+      process.env.NODE_ENV = 'development';
       const cspMiddleware = requireCSP().default;
       cspMiddleware()(req, res, next);
       // eslint-disable-next-line no-underscore-dangle
@@ -65,6 +70,39 @@ describe('csp', () => {
       const headers = res._getHeaders();
       expect(headers).toHaveProperty('content-security-policy');
       expect(headers).not.toHaveProperty('content-security-policy-report-only');
+    });
+
+    it('adds ip and localhost to csp in development', () => {
+      process.env.NODE_ENV = 'development';
+      process.env.HTTP_ONE_APP_DEV_CDN_PORT = 5000;
+      const requiredCsp = requireCSP();
+      const cspMiddleware = requiredCsp.default;
+      const { updateCSP } = requiredCsp;
+      updateCSP("default-src 'none'; script-src 'self'; connect-src 'self';");
+      cspMiddleware()(req, res, next);
+      // eslint-disable-next-line no-underscore-dangle
+      const headers = res._getHeaders();
+      expect(headers).toHaveProperty('content-security-policy');
+      const cspString = headers['content-security-policy'];
+      expect(sanitizeCspString(cspString)).toMatchSnapshot();
+    });
+
+    it('does not add ip and localhost to csp in production', () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.HTTP_ONE_APP_DEV_CDN_PORT;
+      const requiredCsp = requireCSP();
+      const cspMiddleware = requiredCsp.default;
+      const { updateCSP } = requiredCsp;
+      updateCSP("default-src 'none'; script-src 'self'; connect-src 'self';");
+      cspMiddleware()(req, res, next);
+      // eslint-disable-next-line no-underscore-dangle
+      const headers = res._getHeaders();
+      expect(headers).toHaveProperty('content-security-policy');
+      const cspString = headers['content-security-policy'];
+      const ipFound = cspString.match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:3001/);
+      expect(ipFound).toBeNull();
+      const localhostFound = cspString.match(/localhost:3001/);
+      expect(localhostFound).toBeNull();
     });
 
     it('sets script nonce', () => {

--- a/docs/api/modules/App-Configuration.md
+++ b/docs/api/modules/App-Configuration.md
@@ -125,7 +125,7 @@ The `csp` static `String` should be a valid [Content Security Policy (CSP)](http
 
 > We recommend using something like [content-security-policy-builder](https://www.npmjs.com/package/content-security-policy-builder) to create your CSP string. This is set up automatically when you use the [One App module generator](https://github.com/americanexpress/one-app-cli/tree/master/packages/generator-one-app-module).
 
-You'll still want the ability to run One App and serve modules locally without running into CSP errors. When `NODE_ENV=development`, One App will dynamically add both your computer's IP address and `localhost` to the root module's CSP.
+You'll still want the ability to run One App and serve modules locally without running into CSP errors. When `NODE_ENV=development`, One App will dynamically add both your computer's IP address and `localhost` to the root module's CSP. Please note that the `script-src` and `connect-src` directives must already be defined in your CSP in order for this to work properly.
 
 **📘 More Information**
 * Example: [Frank Lloyd Root's CSP](../../../prod-sample/sample-modules/frank-lloyd-root/0.0.0/src/csp.js)

--- a/docs/api/modules/App-Configuration.md
+++ b/docs/api/modules/App-Configuration.md
@@ -123,7 +123,9 @@ if (!global.BROWSER) {
 
 The `csp` static `String` should be a valid [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) for your application which will be passed on to the HTML markup rendered by the Browser.
 
-> We recommend using something like [content-security-policy-builder](https://www.npmjs.com/package/content-security-policy-builder) to create your CSP string.
+> We recommend using something like [content-security-policy-builder](https://www.npmjs.com/package/content-security-policy-builder) to create your CSP string. This is set up automatically when you use the [One App module generator](https://github.com/americanexpress/one-app-cli/tree/master/packages/generator-one-app-module).
+
+You'll still want the ability to run One App and serve modules locally without running into CSP errors. When `NODE_ENV=development`, One App will dynamically add both your computer's IP address and `localhost` to the root module's CSP.
 
 **📘 More Information**
 * Example: [Frank Lloyd Root's CSP](../../../prod-sample/sample-modules/frank-lloyd-root/0.0.0/src/csp.js)

--- a/src/server/middleware/csp.js
+++ b/src/server/middleware/csp.js
@@ -61,8 +61,9 @@ const csp = () => (req, res, next) => {
   const scriptNonce = uuidV4();
   let updatedPolicy;
   if (process.env.NODE_ENV === 'development') {
+    const updatedScriptSrc = insertSource(policy, 'script-src', `'nonce-${scriptNonce}' ${ip.address()}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT} localhost:${process.env.HTTP_ONE_APP_DEV_CDN_PORT}`);
     updatedPolicy = insertSource(
-      insertSource(policy, 'script-src', `'nonce-${scriptNonce}' ${ip.address()}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT} localhost:${process.env.HTTP_ONE_APP_DEV_CDN_PORT}`),
+      updatedScriptSrc,
       'connect-src',
       `${ip.address()}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT} localhost:${process.env.HTTP_ONE_APP_DEV_CDN_PORT}`
     );


### PR DESCRIPTION
moves logic to add IP and `localhost` to csp when `NODE_ENV=development` from root module to One App.

One thing to note: root module _must_ have csp directives (`script-src`, `connect-src`) defined already in order for ip and localhost to be added. One App only adds the values to `script-src` and `connect-src` if they're pre-existing directives.

Feedback on the explanation in the docs is much appreciated.