### PR TITLE
use correct dev.endpoints file format in mocking api calls recipe

### DIFF
--- a/docs/recipes/Mocking-API-Calls.md
+++ b/docs/recipes/Mocking-API-Calls.md
@@ -25,13 +25,12 @@ $ npm run set-dev-endpoints ../[module-name]/dev.endpoints.js
 A `dev.endpoints.js` file looks like:
 
 ```js
-module.exports = () => [
-  {
-    envVarName: 'ONE_CLIENT_APP_API_URL',
-    oneAppDevProxyPath: 'api',
-    destination: 'https://api.com',
+module.exports = () => ({
+  apiUrl: {
+    devProxyPath: 'api',
+    destination: 'https://example.com',
   },
-];
+});
 ```
 
 [☝️ Return To Top](#mocking-your-api-calls-for-local-development)


### PR DESCRIPTION
## Description

After the dev.endpoints file format was updated the corresponding doc was not. This change is to update that doc.

## Motivation and Context
Documentation for mocking api calls is wrong as currently written.


## How Has This Been Tested?
Made sure md parsed well in github

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)

## Checklist:
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?

Improves their lives as the docs are now accurate.
