### PR TITLE
Bug fixes for mocking data

### DIFF
--- a/__tests__/server/middleware/__snapshots__/csp.spec.js.snap
+++ b/__tests__/server/middleware/__snapshots__/csp.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csp middleware adds ip and localhost to csp in development 1`] = `"default-src 'none'; script-src 'nonce-00000000-0000-0000-0000-000000000000' 0.0.0.0:5000 localhost:5000 'self'; connect-src 0.0.0.0:5000 localhost:5000 'self';"`;
+exports[`csp middleware adds ip and localhost to csp in development 1`] = `"default-src 'none'; script-src 'nonce-00000000-0000-0000-0000-000000000000' 0.0.0.0:5000 localhost:5000 'self'; connect-src 0.0.0.0:5000 localhost:5000 0.0.0.0:3001 localhost:3001 'self';"`;
 
 exports[`csp updateCSP updates cspCache with given csp 1`] = `"default-src 'self';"`;

--- a/__tests__/server/middleware/csp.spec.js
+++ b/__tests__/server/middleware/csp.spec.js
@@ -75,6 +75,7 @@ describe('csp', () => {
     it('adds ip and localhost to csp in development', () => {
       process.env.NODE_ENV = 'development';
       process.env.HTTP_ONE_APP_DEV_CDN_PORT = 5000;
+      process.env.HTTP_ONE_APP_DEV_PROXY_SERVER_PORT = 3001;
       const requiredCsp = requireCSP();
       const cspMiddleware = requiredCsp.default;
       const { updateCSP } = requiredCsp;
@@ -90,6 +91,7 @@ describe('csp', () => {
     it('does not add ip and localhost to csp in production', () => {
       process.env.NODE_ENV = 'production';
       delete process.env.HTTP_ONE_APP_DEV_CDN_PORT;
+      delete process.env.HTTP_ONE_APP_DEV_PROXY_SERVER_PORT;
       const requiredCsp = requireCSP();
       const cspMiddleware = requiredCsp.default;
       const { updateCSP } = requiredCsp;

--- a/__tests__/server/utils/stateConfig.spec.js
+++ b/__tests__/server/utils/stateConfig.spec.js
@@ -195,6 +195,22 @@ describe('stateConfig methods', () => {
         expect(getClientStateConfig()).toMatchSnapshot();
         expect(getServerStateConfig()).toMatchSnapshot();
       });
+      it('dev endpoint should not have doubled slash in path', () => {
+        process.env.NODE_ENV = 'development';
+        // eslint-disable-next-line unicorn/import-index, import/no-unresolved
+        require('fake/path/.dev/endpoints/index.js').mockImplementation(() => ({
+          leadingSlashApiUrl: {
+            devProxyPath: '/leading-slash-api',
+            destination: 'https://intranet-origin-dev.example.com/some-other-api/v1',
+          },
+        }));
+        ({
+          setStateConfig,
+          getClientStateConfig,
+          getServerStateConfig,
+        } = require('../../../src/server/utils/stateConfig'));
+        expect(getClientStateConfig().leadingSlashApiUrl).toEqual('http://127.0.0.1:3002/leading-slash-api');
+      });
     });
     describe('with env vars', () => {
       it('should parse string undefined as js undefined', () => {

--- a/src/server/middleware/csp.js
+++ b/src/server/middleware/csp.js
@@ -65,7 +65,12 @@ const csp = () => (req, res, next) => {
     updatedPolicy = insertSource(
       updatedScriptSrc,
       'connect-src',
-      `${ip.address()}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT} localhost:${process.env.HTTP_ONE_APP_DEV_CDN_PORT}`
+      [
+        `${ip.address()}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT}`,
+        `localhost:${process.env.HTTP_ONE_APP_DEV_CDN_PORT}`,
+        `${ip.address()}:${process.env.HTTP_ONE_APP_DEV_PROXY_SERVER_PORT}`,
+        `localhost:${process.env.HTTP_ONE_APP_DEV_PROXY_SERVER_PORT}`,
+      ].join(' ')
     );
   } else {
     updatedPolicy = insertSource(policy, 'script-src', `'nonce-${scriptNonce}'`);

--- a/src/server/utils/stateConfig.js
+++ b/src/server/utils/stateConfig.js
@@ -17,6 +17,7 @@
 import ip from 'ip';
 import fs from 'fs';
 import path from 'path';
+import url from 'url';
 import envVarAllowList from './envVarAllowList';
 import snakeCaseToCamelCase from './snakeCaseToCamelCase';
 
@@ -76,7 +77,12 @@ if (process.env.NODE_ENV === 'development' && fs.existsSync(pathToDevEndpoints))
   // eslint-disable-next-line global-require,import/no-dynamic-require
   const devEndpoints = require(pathToDevEndpoints)();
   Object.entries(devEndpoints).forEach(([configName, { devProxyPath }]) => {
-    const value = `http://${ipAddress}:${SERVICES_PORT}/${devProxyPath}`;
+    const value = url.format({
+      protocol: 'http',
+      hostname: ipAddress,
+      port: SERVICES_PORT,
+      pathname: devProxyPath,
+    });
     stateConfigFromDevEndpoints[configName] = value;
   });
 }


### PR DESCRIPTION
## Description
- FIx csp directives to include dev proxy server port.
- Fix path joining in state config.

## Motivation and Context
Solves csp directives not including dev proxy server port.
Solves incorrect double slash `//` in path naming.  

## How Has This Been Tested?
Includes tests to validate desired behavior.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)

## Checklist:
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [x] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
Dev proxy server port should appear on csp directives, allowing proper testing with parrot.
Allows defining paths in mock endpoints with leading or no leading slash.
