### PR TITLE
test(integration/pwa): inconsistent active state string

### DIFF
--- a/__tests__/integration/one-app.spec.js
+++ b/__tests__/integration/one-app.spec.js
@@ -934,7 +934,6 @@ describe('Tests that require Docker setup', () => {
             installing: null,
             active: {
               scriptURL: scriptUrl.replace(appAtTestUrls.fetchUrl, appAtTestUrls.browserUrl),
-              state: 'activated',
             },
             scope: `${appAtTestUrls.browserUrl}/`,
             updateViaCache: 'none',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Removes a flaky integration test where the `{ active: { state: 'activated' } }` but often comes back as `registration.active.state === 'activating'`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
None