### PR TITLE
docs(api/app-config): add caution on state config

### DIFF
--- a/docs/api/modules/App-Configuration.md
+++ b/docs/api/modules/App-Configuration.md
@@ -96,7 +96,7 @@ The `provideStateConfig` directive is useful for supplying string-based key valu
 
 > Server specific values used within state config are not isolated from the client side, as they are used
 > while rendering server side Holocron modules. Please use caution not to expose any sensitive data in a
-> Holocron module while using `state.get('config')` server-side while rendering markup in your module.
+> Holocron module when using `state.get('config')` server-side and rendering markup in your module.
 
 In practice, the state config supplied by a Root Module may look like this shape:
 

--- a/docs/api/modules/App-Configuration.md
+++ b/docs/api/modules/App-Configuration.md
@@ -92,6 +92,12 @@ if (!global.BROWSER) {
 
 The `provideStateConfig` directive is useful for supplying string-based key value settings per runtime (e.g. `client` or `server`) and per `environmentLevel` (e.g. QA, Prod, etc). The `environmentLevel` is specified in the [`ONE_CONFIG_ENV` environment variable](../server/Environment-Variables.md#one_config_env) when running the Server.
 
+**⚠️ Please Consider**
+
+> Server specific values used within state config are not isolated from the client side, as they are used
+> while rendering server side Holocron modules. Please use caution not to expose any sensitive data in a
+> Holocron module while using `state.get('config')` server-side while rendering markup in your module.
+
 In practice, the state config supplied by a Root Module may look like this shape:
 
 ```js

--- a/docs/api/modules/App-Configuration.md
+++ b/docs/api/modules/App-Configuration.md
@@ -96,7 +96,7 @@ The `provideStateConfig` directive is useful for supplying string-based key valu
 
 > Server specific values used within state config are not isolated from the client side, as they are used
 > while rendering server side Holocron modules. Please use caution not to expose any sensitive data in a
-> Holocron module when using `state.get('config')` server-side and rendering markup in your module.
+> Holocron module while using `state.get('config')` for any server side rendering in your module.
 
 In practice, the state config supplied by a Root Module may look like this shape:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding an advisory on using `provideStateConfig` and server specific values in docs.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Warn not to expose sensitive data and prevent leaks.