### PR TITLE
refactor(sample-modules): holocron config

### DIFF
--- a/prod-sample/sample-modules/cultured-frankie/0.0.0/src/components/CulturedFrankie.jsx
+++ b/prod-sample/sample-modules/cultured-frankie/0.0.0/src/components/CulturedFrankie.jsx
@@ -19,8 +19,6 @@ import PropTypes from 'prop-types';
 import { loadLanguagePack, updateLocale } from '@americanexpress/one-app-ducks';
 import { FormattedMessage, IntlProvider } from 'react-intl';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
 import { fromJS } from 'immutable';
 
 const CulturedFrankie = ({ switchLanguage, languageData, localeName }) => {
@@ -53,6 +51,11 @@ CulturedFrankie.propTypes = {
   }).isRequired,
   localeName: PropTypes.string.isRequired,
 };
+CulturedFrankie.holocron = {
+  name: 'cultured-frankie',
+  load: () => (dispatch) => dispatch(loadLanguagePack('cultured-frankie', { fallbackLocale: 'en-US' })),
+  options: { ssr: true },
+};
 
 const mapDispatchToProps = (dispatch) => ({
   switchLanguage: async ({ target }) => {
@@ -74,11 +77,4 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  holocronModule({
-    name: 'cultured-frankie',
-    load: () => (dispatch) => dispatch(loadLanguagePack('cultured-frankie', { fallbackLocale: 'en-US' })),
-    options: { ssr: true },
-  })
-)(CulturedFrankie);
+export default connect(mapStateToProps, mapDispatchToProps)(CulturedFrankie);

--- a/prod-sample/sample-modules/cultured-frankie/0.0.0/src/components/CulturedFrankie.jsx
+++ b/prod-sample/sample-modules/cultured-frankie/0.0.0/src/components/CulturedFrankie.jsx
@@ -53,8 +53,10 @@ CulturedFrankie.propTypes = {
 };
 CulturedFrankie.holocron = {
   name: 'cultured-frankie',
-  load: () => (dispatch) => dispatch(loadLanguagePack('cultured-frankie', { fallbackLocale: 'en-US' })),
   options: { ssr: true },
+  loadModuleData: ({ store: { dispatch } }) => dispatch(
+    loadLanguagePack('cultured-frankie', { fallbackLocale: 'en-US' })
+  ),
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/prod-sample/sample-modules/cultured-frankie/0.0.1/src/components/CulturedFrankie.jsx
+++ b/prod-sample/sample-modules/cultured-frankie/0.0.1/src/components/CulturedFrankie.jsx
@@ -19,8 +19,6 @@ import PropTypes from 'prop-types';
 import { loadLanguagePack, updateLocale } from '@americanexpress/one-app-ducks';
 import { FormattedMessage, IntlProvider } from 'react-intl';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
 import { fromJS } from 'immutable';
 
 const CulturedFrankie = ({ switchLanguage, languageData, localeName }) => {
@@ -54,6 +52,12 @@ CulturedFrankie.propTypes = {
   localeName: PropTypes.string.isRequired,
 };
 
+CulturedFrankie.holocron = {
+  name: 'cultured-frankie',
+  load: () => (dispatch) => dispatch(loadLanguagePack('cultured-frankie', { fallbackLocale: 'en-US' })),
+  options: { ssr: true },
+};
+
 const mapDispatchToProps = (dispatch) => ({
   switchLanguage: async ({ target }) => {
     await dispatch(updateLocale(target.value));
@@ -74,11 +78,4 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  holocronModule({
-    name: 'cultured-frankie',
-    load: () => (dispatch) => dispatch(loadLanguagePack('cultured-frankie', { fallbackLocale: 'en-US' })),
-    options: { ssr: true },
-  })
-)(CulturedFrankie);
+export default connect(mapStateToProps, mapDispatchToProps)(CulturedFrankie);

--- a/prod-sample/sample-modules/cultured-frankie/0.0.1/src/components/CulturedFrankie.jsx
+++ b/prod-sample/sample-modules/cultured-frankie/0.0.1/src/components/CulturedFrankie.jsx
@@ -54,8 +54,10 @@ CulturedFrankie.propTypes = {
 
 CulturedFrankie.holocron = {
   name: 'cultured-frankie',
-  load: () => (dispatch) => dispatch(loadLanguagePack('cultured-frankie', { fallbackLocale: 'en-US' })),
   options: { ssr: true },
+  loadModuleData: ({ store: { dispatch } }) => dispatch(
+    loadLanguagePack('cultured-frankie', { fallbackLocale: 'en-US' })
+  ),
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/prod-sample/sample-modules/frank-lloyd-root/0.0.0/src/components/FrankLloydRoot.jsx
+++ b/prod-sample/sample-modules/frank-lloyd-root/0.0.0/src/components/FrankLloydRoot.jsx
@@ -20,10 +20,8 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { fromJS } from 'immutable';
 import ModuleRoute from 'holocron-module-route';
-import { holocronModule } from 'holocron';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
 import HelloWorldComponent from './HelloWorld';
 import Partial, { onPartialRouteEnter } from './Partial';
 
@@ -68,10 +66,9 @@ reducer.buildInitialState = ({ req } = {}) => {
   return fromJS({});
 };
 
-export default compose(
-  connect((state) => ({ config: state.get('config') })),
-  holocronModule({
-    name: 'frank-lloyd-root',
-    reducer,
-  })
-)(FrankLloydRoot);
+FrankLloydRoot.holocron = {
+  name: 'frank-lloyd-root',
+  reducer,
+};
+
+export default connect((state) => ({ config: state.get('config') }))(FrankLloydRoot);

--- a/prod-sample/sample-modules/frank-lloyd-root/0.0.1/src/components/FrankLloydRoot.jsx
+++ b/prod-sample/sample-modules/frank-lloyd-root/0.0.1/src/components/FrankLloydRoot.jsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { fromJS } from 'immutable';
 import ModuleRoute from 'holocron-module-route';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
@@ -62,13 +61,5 @@ if (!global.BROWSER) {
     },
   };
 }
-
-const reducer = (state = fromJS({})) => state;
-reducer.buildInitialState = ({ req } = {}) => {
-  if (req && req.body) {
-    return fromJS({ postProps: req.body });
-  }
-  return fromJS({});
-};
 
 export default connect((state) => ({ config: state.get('config') }))(FrankLloydRoot);

--- a/prod-sample/sample-modules/frank-lloyd-root/0.0.2/src/components/FrankLloydRoot.jsx
+++ b/prod-sample/sample-modules/frank-lloyd-root/0.0.2/src/components/FrankLloydRoot.jsx
@@ -19,10 +19,8 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { fromJS } from 'immutable';
 import ModuleRoute from 'holocron-module-route';
-import { holocronModule } from 'holocron';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
 import HelloWorldComponent from './HelloWorld';
 import Partial, { onPartialRouteEnter } from './Partial';
 
@@ -67,10 +65,9 @@ reducer.buildInitialState = ({ req } = {}) => {
   return fromJS({});
 };
 
-export default compose(
-  connect((state) => ({ config: state.get('config') })),
-  holocronModule({
-    name: 'frank-lloyd-root',
-    reducer,
-  })
-)(FrankLloydRoot);
+FrankLloydRoot.holocron = {
+  name: 'frank-lloyd-root',
+  reducer,
+};
+
+export default connect((state) => ({ config: state.get('config') }))(FrankLloydRoot);

--- a/prod-sample/sample-modules/franks-burgers/0.0.0/src/components/index.jsx
+++ b/prod-sample/sample-modules/franks-burgers/0.0.0/src/components/index.jsx
@@ -19,8 +19,6 @@ import PropTypes from 'prop-types';
 import { loadLanguagePack } from '@americanexpress/one-app-ducks';
 import { FormattedMessage, IntlProvider } from 'react-intl';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
 import { fromJS } from 'immutable';
 
 const Burger = React.lazy(() => import(/* webpackChunkName: 'Burger' */ './Burger'));
@@ -73,6 +71,12 @@ FranksBurgers.propTypes = {
   }).isRequired,
 };
 
+FranksBurgers.holocron = {
+  name: 'franks-burgers',
+  load: () => (dispatch) => dispatch(loadLanguagePack('franks-burgers', { fallbackLocale: 'en-US' })),
+  options: { ssr: true },
+};
+
 const mapStateToProps = (state) => {
   const localeName = state.getIn(['intl', 'activeLocale']);
   const languagePack = state.getIn(
@@ -86,11 +90,4 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default compose(
-  connect(mapStateToProps),
-  holocronModule({
-    name: 'franks-burgers',
-    load: () => (dispatch) => dispatch(loadLanguagePack('franks-burgers', { fallbackLocale: 'en-US' })),
-    options: { ssr: true },
-  })
-)(FranksBurgers);
+export default connect(mapStateToProps)(FranksBurgers);

--- a/prod-sample/sample-modules/franks-burgers/0.0.0/src/components/index.jsx
+++ b/prod-sample/sample-modules/franks-burgers/0.0.0/src/components/index.jsx
@@ -73,8 +73,10 @@ FranksBurgers.propTypes = {
 
 FranksBurgers.holocron = {
   name: 'franks-burgers',
-  load: () => (dispatch) => dispatch(loadLanguagePack('franks-burgers', { fallbackLocale: 'en-US' })),
   options: { ssr: true },
+  loadModuleData: ({ store: { dispatch } }) => dispatch(
+    loadLanguagePack('franks-burgers', { fallbackLocale: 'en-US' })
+  ),
 };
 
 const mapStateToProps = (state) => {

--- a/prod-sample/sample-modules/needy-frank/0.0.0/src/components/NeedyFrank.jsx
+++ b/prod-sample/sample-modules/needy-frank/0.0.0/src/components/NeedyFrank.jsx
@@ -15,8 +15,6 @@
  */
 
 import React from 'react';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
 import { configureIguazuSSR } from 'iguazu-holocron';
 import PropTypes from 'prop-types';
 import { connectAsync } from 'iguazu';
@@ -51,10 +49,9 @@ NeedyFrank.propTypes = {
   }).isRequired,
 };
 
-export default compose(
-  holocronModule({
-    name: 'needy-frank',
-    reducer,
-  }),
-  connectAsync({ loadDataAsProps })
-)(NeedyFrank);
+NeedyFrank.holocron = {
+  name: 'needy-frank',
+  reducer,
+};
+
+export default connectAsync({ loadDataAsProps })(NeedyFrank);

--- a/prod-sample/sample-modules/needy-frank/0.0.1/src/components/NeedyFrank.jsx
+++ b/prod-sample/sample-modules/needy-frank/0.0.1/src/components/NeedyFrank.jsx
@@ -15,8 +15,6 @@
  */
 
 import React from 'react';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
 import { configureIguazuSSR } from 'iguazu-holocron';
 import PropTypes from 'prop-types';
 import { connectAsync } from 'iguazu';
@@ -45,10 +43,9 @@ NeedyFrank.propTypes = {
   moduleState: PropTypes.shape({}).isRequired,
 };
 
-export default compose(
-  connectAsync({ loadDataAsProps }),
-  holocronModule({
-    name: 'needy-frank',
-    reducer,
-  })
-)(NeedyFrank);
+NeedyFrank.holocron = {
+  name: 'needy-frank',
+  reducer,
+};
+
+export default connectAsync({ loadDataAsProps })(NeedyFrank);

--- a/prod-sample/sample-modules/preview-frank/0.0.0/src/components/PreviewFrank.jsx
+++ b/prod-sample/sample-modules/preview-frank/0.0.0/src/components/PreviewFrank.jsx
@@ -17,8 +17,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { compose } from 'redux';
-import { RenderModule, holocronModule } from 'holocron';
+import { RenderModule } from 'holocron';
 import { load } from '../duck';
 import getDemoProps from '../utils/getDemoProps';
 
@@ -58,17 +57,14 @@ PreviewFrank.propTypes = {
   moduleToBeDemoedExists: PropTypes.bool.isRequired,
 };
 
+PreviewFrank.holocron = {
+  name: 'preview-frank',
+  load,
+  options: { ssr: true },
+};
+
 export const mapStateToProps = (state, ownProps) => ({
   moduleToBeDemoedExists: state.hasIn(['holocron', 'loaded', ownProps.params.moduleName]),
 });
 
-const hocChain = compose(
-  connect(mapStateToProps),
-  holocronModule({
-    name: 'preview-frank',
-    load,
-    options: { ssr: true },
-  })
-);
-
-export default hocChain(PreviewFrank);
+export default connect(mapStateToProps)(PreviewFrank);

--- a/prod-sample/sample-modules/preview-frank/0.0.0/src/components/PreviewFrank.jsx
+++ b/prod-sample/sample-modules/preview-frank/0.0.0/src/components/PreviewFrank.jsx
@@ -18,7 +18,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { RenderModule } from 'holocron';
-import { load } from '../duck';
+import { loadModuleData } from '../duck';
 import getDemoProps from '../utils/getDemoProps';
 
 const PreviewFrank = (props) => {
@@ -59,7 +59,7 @@ PreviewFrank.propTypes = {
 
 PreviewFrank.holocron = {
   name: 'preview-frank',
-  load,
+  loadModuleData,
   options: { ssr: true },
 };
 

--- a/prod-sample/sample-modules/preview-frank/0.0.0/src/duck.js
+++ b/prod-sample/sample-modules/preview-frank/0.0.0/src/duck.js
@@ -23,18 +23,16 @@ import getDemoProps from './utils/getDemoProps';
 // This duck does not have a reducer
 export default null;
 
-export function load(props) {
+export function loadModuleData({ store: { dispatch }, ownProps: props }) {
   const { location, params } = props;
-  return (dispatch) => {
-    const demoProps = getDemoProps(props);
-    const locale = get(location, 'query.locale');
+  const demoProps = getDemoProps(props);
+  const locale = get(location, 'query.locale');
 
-    const promises = [
-      dispatch(composeModules([{ name: params.moduleName, props: demoProps }])),
-    ];
+  const promises = [
+    dispatch(composeModules([{ name: params.moduleName, props: demoProps }])),
+  ];
 
-    return locale
-      ? Promise.all([...promises, dispatch(updateLocale(locale))])
-      : Promise.all(promises);
-  };
+  return locale
+    ? Promise.all([...promises, dispatch(updateLocale(locale))])
+    : Promise.all(promises);
 }

--- a/prod-sample/sample-modules/vitruvius-franklin/0.0.0/src/components/VitruviusFranklin.jsx
+++ b/prod-sample/sample-modules/vitruvius-franklin/0.0.0/src/components/VitruviusFranklin.jsx
@@ -16,8 +16,7 @@
 
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
+
 import reducer from '../duck';
 
 export function VitruviusFranklin({ moduleState }) {
@@ -39,18 +38,15 @@ if (!global.BROWSER) {
   };
 }
 
-
 VitruviusFranklin.propTypes = {
   moduleState: PropTypes.shape({
     req: PropTypes.object,
   }).isRequired,
 };
 
-const hocChain = compose(
-  holocronModule({
-    name: 'vitruvius-franklin',
-    reducer,
-  })
-);
+VitruviusFranklin.holocron = {
+  name: 'vitruvius-franklin',
+  reducer,
+};
 
-export default hocChain(VitruviusFranklin);
+export default VitruviusFranklin;

--- a/prod-sample/sample-modules/vitruvius-franklin/0.0.1/src/components/VitruviusFranklin.jsx
+++ b/prod-sample/sample-modules/vitruvius-franklin/0.0.1/src/components/VitruviusFranklin.jsx
@@ -16,8 +16,7 @@
 
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'redux';
-import { holocronModule } from 'holocron';
+
 import reducer from '../duck';
 
 export function VitruviusFranklin({ moduleState }) {
@@ -39,18 +38,15 @@ if (!global.BROWSER) {
   };
 }
 
-
 VitruviusFranklin.propTypes = {
   moduleState: PropTypes.shape({
     req: PropTypes.object,
   }).isRequired,
 };
 
-const hocChain = compose(
-  holocronModule({
-    name: 'vitruvius-franklin',
-    reducer,
-  })
-);
+VitruviusFranklin.holocron = {
+  name: 'vitruvius-franklin',
+  reducer,
+};
 
-export default hocChain(VitruviusFranklin);
+export default VitruviusFranklin;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update sample modules to use the updated Holocron API.

## Description
<!--- Describe your changes in detail -->
Removed `holocronModule` in favor of `Module.holocron` for configuring modules.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keep sample modules up to date.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Test suite.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Sample modules are up to date.