### PR TITLE
fix(scripts/watch): ensure missing sw scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "concurrently \"npm run build:bundle\" \"npm run build:server\" -n build:bundle,build:server --kill-others-on-fail && npm run build:service-workers",
     "build:prod-sample": "concurrently \"npm run build:sample-modules\" \"node scripts/build-one-app-docker-setup.js\" -n build-modules,build-app",
     "build:sample-modules": "node scripts/build-sample-modules.js",
-    "start:watch": "nodemon --signal SIGTERM --watch src --ext js,jsx --exec babel-node src/server/index.js",
+    "start:watch": "node scripts/watch-server.js",
     "prestart:prod-sample": "npm run build:prod-sample",
     "start:prod-sample": "docker-compose -f ./prod-sample/docker-compose.yml up --abort-on-container-exit",
     "test:lockfile": "lockfile-lint -p package-lock.json -t npm -a npm -o https: -c -i",

--- a/scripts/watch-server.js
+++ b/scripts/watch-server.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2020 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+const { spawn } = require('child_process');
+const buildServiceWorkerScripts = require('./build-service-workers');
+
+(async function dev() {
+  const { watcher } = await buildServiceWorkerScripts({ dev: true, watch: true, minify: false });
+  watcher.on('event', (event) => {
+    switch (event.code) {
+      case 'ERROR':
+        console.error(event.error);
+        break;
+      case 'START':
+        console.log('Service Workers have %sed building', event.code.toLowerCase());
+        break;
+      case 'BUNDLE_END':
+        console.log('Service Workers built in %d seconds', event.duration / 1000);
+        break;
+      default:
+        break;
+    }
+  });
+
+  const babelWatch = spawn('npm', ['run', 'build:server', '--', '--watch'], {
+    stdio: 'inherit',
+    killSignal: 'SIGINT',
+  });
+
+  const nodemon = spawn('nodemon', ['--signal', 'SIGTERM', '--watch', 'src', '--ext', 'js,jsx', 'lib/server/index.js'], {
+    stdio: 'inherit',
+    killSignal: 'SIGINT',
+  });
+
+  process.on('exit', (code) => {
+    watcher.close();
+    babelWatch.kill(code);
+    nodemon.kill(code);
+  });
+}());

--- a/scripts/watch-server.js
+++ b/scripts/watch-server.js
@@ -42,7 +42,16 @@ const buildServiceWorkerScripts = require('./build-service-workers');
     killSignal: 'SIGINT',
   });
 
-  const nodemon = spawn('nodemon', ['--signal', 'SIGTERM', '--watch', 'src', '--ext', 'js,jsx', 'lib/server/index.js'], {
+  const flags = process.argv.filter((arg) => [
+    '--root-module-name',
+    '--module-map-url',
+    '--use-middleware',
+    '--use-host',
+  ].find((argName) => arg.startsWith(argName)));
+
+  const nodemon = spawn('nodemon', [
+    '--signal', 'SIGTERM', '--watch', 'src', '--ext', 'js,jsx', 'lib/server/index.js',
+  ].concat(flags.length > 0 ? ['--', ...flags] : []), {
     stdio: 'inherit',
     killSignal: 'SIGINT',
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug with `start:watch` not able to load the service worker scripts and fails.

## Description
<!--- Describe your changes in detail -->
Added `scripts/watch-server.js` which watches the server, service worker scripts and rebuilds when either are updated.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix `start:watch` `npm` script.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manual testing during development.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Working local development when using `start:watch` script.