### PR TITLE
chore(dependabot): update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,240 +4,302 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "one app"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/cultured-frankie/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "cultured frankie v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/cultured-frankie/0.0.1"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "cultured frankie v0.0.1"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-lloyd-root/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "frank lloyd root v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-lloyd-root/0.0.1"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "frank lloyd root v0.0.1"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-lloyd-root/0.0.2"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "frank lloyd root v0.0.2"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-lloyd-root/0.0.3"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "frank lloyd root v0.0.3"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-the-parrot/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "frank the parrot v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/franks-burgers/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "franks burgers v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/healthy-frank/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "healthy frank v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/late-frank/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "late frank v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/late-frank/0.0.1"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "late frank v0.0.1"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/late-frank/0.0.2"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "late frank v0.0.2"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/needy-frank/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "needy frank v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/needy-frank/0.0.1"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "needy frank v0.0.1"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/picky-frank/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "picky frank v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/picky-frank/0.0.1"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "picky frank v0.0.1"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/preview-frank/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "preview frank v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/ssr-frank/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "ssr frank v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/vitruvius-franklin/0.0.0"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "vitruvius franklin v0.0.0"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/vitruvius-franklin/0.0.1"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "npm"
       - "dependencies"
       - "dependabot"
       - "prod samples"
       - "vitruvius franklin v0.0.1"
+    automerged_updates:
+      - match:
+          dependency_type: all
+          update_type: semver:patch
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 10
     labels:
       - "docker"
       - "dependabot"
@@ -246,8 +308,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
     labels:
       - "github-actions"
       - "dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,6 @@ updates:
       - "dependencies"
       - "dependabot"
       - "one app"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/cultured-frankie/0.0.0"
     schedule:
@@ -24,10 +20,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "cultured frankie v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/cultured-frankie/0.0.1"
     schedule:
@@ -38,10 +30,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "cultured frankie v0.0.1"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-lloyd-root/0.0.0"
     schedule:
@@ -52,10 +40,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "frank lloyd root v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-lloyd-root/0.0.1"
     schedule:
@@ -66,10 +50,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "frank lloyd root v0.0.1"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-lloyd-root/0.0.2"
     schedule:
@@ -80,10 +60,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "frank lloyd root v0.0.2"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-lloyd-root/0.0.3"
     schedule:
@@ -94,10 +70,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "frank lloyd root v0.0.3"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/frank-the-parrot/0.0.0"
     schedule:
@@ -108,10 +80,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "frank the parrot v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/franks-burgers/0.0.0"
     schedule:
@@ -122,10 +90,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "franks burgers v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/healthy-frank/0.0.0"
     schedule:
@@ -136,10 +100,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "healthy frank v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/late-frank/0.0.0"
     schedule:
@@ -150,10 +110,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "late frank v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/late-frank/0.0.1"
     schedule:
@@ -164,10 +120,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "late frank v0.0.1"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/late-frank/0.0.2"
     schedule:
@@ -178,10 +130,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "late frank v0.0.2"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/needy-frank/0.0.0"
     schedule:
@@ -192,10 +140,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "needy frank v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/needy-frank/0.0.1"
     schedule:
@@ -206,10 +150,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "needy frank v0.0.1"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/picky-frank/0.0.0"
     schedule:
@@ -220,10 +160,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "picky frank v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/picky-frank/0.0.1"
     schedule:
@@ -234,10 +170,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "picky frank v0.0.1"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/preview-frank/0.0.0"
     schedule:
@@ -248,10 +180,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "preview frank v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/ssr-frank/0.0.0"
     schedule:
@@ -262,10 +190,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "ssr frank v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/vitruvius-franklin/0.0.0"
     schedule:
@@ -276,10 +200,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "vitruvius franklin v0.0.0"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
   - package-ecosystem: "npm"
     directory: "/prod-samples/sample-modules/vitruvius-franklin/0.0.1"
     schedule:
@@ -290,10 +210,6 @@ updates:
       - "dependabot"
       - "prod samples"
       - "vitruvius franklin v0.0.1"
-    automerged_updates:
-      - match:
-          dependency_type: all
-          update_type: semver:patch
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changes weekly dependabot runs to monthly. Furthermore, I removed `open-pull-requests-limit` that was set to 10 to revert it back to the default 5.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Decrease the amount of dependabot PRs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
N/A