### PR TITLE
fix(watchLocalModules): wait for change to finish

### DIFF
--- a/__tests__/server/utils/watchLocalModules.spec.js
+++ b/__tests__/server/utils/watchLocalModules.spec.js
@@ -79,7 +79,7 @@ describe('watchLocalModules', () => {
 
   it('should watch the modules directory', () => {
     watchLocalModules();
-    expect(chokidar.watch).toHaveBeenCalledWith(path.resolve(__dirname, '../../../static/modules'));
+    expect(chokidar.watch).toHaveBeenCalledWith(path.resolve(__dirname, '../../../static/modules'), { awaitWriteFinish: true });
   });
 
   it('should update the module registry when a server bundle changes', async () => {

--- a/src/server/utils/watchLocalModules.js
+++ b/src/server/utils/watchLocalModules.js
@@ -36,14 +36,13 @@ export default function watchLocalModules() {
   const staticsDirectoryPath = path.resolve(__dirname, '../../../static');
   const moduleDirectory = path.resolve(staticsDirectoryPath, 'modules');
   const moduleMapPath = path.resolve(staticsDirectoryPath, 'module-map.json');
-  const watcher = chokidar.watch(moduleDirectory);
+  const watcher = chokidar.watch(moduleDirectory, { awaitWriteFinish: true });
 
   watcher.on('change', async (changedPath) => {
     if (!changedPath.endsWith('.node.js')) return;
 
     const match = changedPath.substring(moduleDirectory.length).match(/\/([^/]+)\/([^/]+)/);
     if (!match) return;
-
     const [, moduleNameChangeDetectedIn] = match;
 
     const moduleMap = JSON.parse(fs.readFileSync(moduleMapPath, 'utf8'));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This ensures that `chokidar` waits for the the file to be stable before firing `change` event.

- https://github.com/paulmillr/chokidar#performance see awaitWriteFinish

> in some cases some change events will be emitted while the file is being written. In some cases, especially when watching for large files there will be a need to wait for the write operation to finish before responding to a file creation or modification

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
One App crashing when large modules are rebuilt

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
used an oversized root module, was able to produce crashing of one-app 3/4 attemps. After change could not reproduce crash. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Should no longer crash when large modules are rebuilt.