### PR TITLE
fix(integration): flaky pwa cache checks

### DIFF
--- a/__tests__/integration/one-app.spec.js
+++ b/__tests__/integration/one-app.spec.js
@@ -1001,10 +1001,12 @@ describe('Tests that require Docker setup', () => {
 
               await expect(browser.executeAsync(getCacheMatch, shell)).resolves.toBeDefined();
               await expect(browser.executeAsync(getCacheMatch, manifest)).resolves.toBeDefined();
-              expect(cacheMap.get('__sw/offline')).toEqual([
-                manifest,
-                shell,
-              ]);
+              expect(cacheMap.get('__sw/offline')).toEqual(
+                expect.arrayContaining([
+                  manifest,
+                  shell,
+                ])
+              );
             });
 
             test('caches the app assets and entry root module', async () => {
@@ -1017,17 +1019,16 @@ describe('Tests that require Docker setup', () => {
               const holocronModuleMap = readModuleMap();
               const cacheKeys = await browser.executeAsync(getCacheKeys);
               const cacheMap = new Map(await browser.executeAsync(getCacheEntries, cacheKeys));
+              const oneAppCacheURLs = cacheMap.get('__sw/one-app').map((url) => url.replace(
+                url.match(oneAppVersionRegExp)[1],
+                '[one-app-version]'
+              ));
 
               expect(cacheMap.get('__sw/lang-packs')).toBeUndefined();
               expect(cacheMap.get('__sw/modules')).toEqual([
                 holocronModuleMap.modules['frank-lloyd-root'].browser.url,
               ]);
-              expect(
-                cacheMap.get('__sw/one-app').map((url) => url.replace(
-                  url.match(oneAppVersionRegExp)[1],
-                  '[one-app-version]'
-                ))
-              ).toEqual(
+              expect(oneAppCacheURLs).toEqual(
                 expect.arrayContaining(
                   [
                     // the build output directory uses the git sha which
@@ -1057,19 +1058,19 @@ describe('Tests that require Docker setup', () => {
               const holocronModuleMap = readModuleMap();
               const cacheKeys = await browser.executeAsync(getCacheKeys);
               const cacheMap = new Map(await browser.executeAsync(getCacheEntries, cacheKeys));
+              const burgerChunkURL = holocronModuleMap.modules['franks-burgers'].browser.url.replace(
+                'franks-burgers.browser.js',
+                'Burger.chunk.browser.js'
+              );
 
               expect(cacheMap.get('__sw/modules')).toHaveLength(4);
               expect(cacheMap.get('__sw/modules')).toEqual(
-                [
+                expect.arrayContaining([
                   holocronModuleMap.modules['frank-lloyd-root'].browser.url,
                   holocronModuleMap.modules['preview-frank'].browser.url,
                   holocronModuleMap.modules['franks-burgers'].browser.url,
-                  // the module chunk
-                  holocronModuleMap.modules['franks-burgers'].browser.url.replace(
-                    'franks-burgers.browser.js',
-                    'Burger.franks-burgers.chunk.browser.js'
-                  ),
-                ]
+                  burgerChunkURL,
+                ])
               );
             });
           });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Some fixes for the PWA integration tests to remove inconsistent caching order.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.