### PR TITLE
feat(ssrServer): enable urlencoded post data

### DIFF
--- a/__tests__/integration/one-app.spec.js
+++ b/__tests__/integration/one-app.spec.js
@@ -1300,6 +1300,27 @@ describe('Tests that can run against either local Docker setup or remote One App
           sendingData: 'in POSTs',
         });
       });
+      test('app passes urlencoded POST data to modules via vitruvius', async () => {
+        const response = await fetch(
+          `${appInstanceUrls.fetchUrl}/vitruvius`,
+          {
+            ...defaultFetchOpts,
+            method: 'POST',
+            headers: {
+              'content-type': 'application/x-www-form-urlencoded',
+            },
+            body: 'legacy=application&sendingData=in POSTs',
+          }
+        );
+
+        const pageHtml = await response.text();
+        const data = JSON.parse(pageHtml.match(/<pre>([^<]+)<\/pre>/)[1].replace(/&quot;/g, '"'));
+        expect(data).toHaveProperty('req.body');
+        expect(data.req.body).toEqual({
+          legacy: 'application',
+          sendingData: 'in POSTs',
+        });
+      });
 
       describe('routing', () => {
         test('IndexRedirect redirects', async () => {

--- a/docs/recipes/Making-An-Api-Call.md
+++ b/docs/recipes/Making-An-Api-Call.md
@@ -6,4 +6,13 @@
 
 Recipe is forthcoming.
 
+## POST
+To enable post set [`ONE_ENABLE_POST_TO_MODULE_ROUTES`](../api/server/Environment-Variables.md#ONE_ENABLE_POST_TO_MODULE_ROUTES) environment variable.
+Request body must be either a JSON object or FormData of less than 15KB in size and is passed as props to your module.
+
+Supported media types:
+- `application/json`
+- `application/x-www-form-urlencoded`
+
+
 [☝️ Return To Top](#Making-An-Api-Call)

--- a/src/server/ssrServer.js
+++ b/src/server/ssrServer.js
@@ -23,7 +23,7 @@ import path from 'path';
 import express from 'express';
 import compression from 'compression';
 import cookieParser from 'cookie-parser';
-import { json } from 'body-parser';
+import { json, urlencoded } from 'body-parser';
 import helmet from 'helmet';
 import cors from 'cors';
 
@@ -96,6 +96,7 @@ export function createApp({ enablePostToModuleRoutes = false } = {}) {
       '*',
       addSecurityHeaders,
       json({ limit: '0kb' }), // there should be no body
+      urlencoded({ limit: '0kb' }), // there should be no body
       cors({ origin: false }) // disable CORS
     );
 
@@ -103,6 +104,7 @@ export function createApp({ enablePostToModuleRoutes = false } = {}) {
       '*',
       addSecurityHeaders,
       json({ limit: '15kb' }),
+      urlencoded({ limit: '15kb' }),
       addFrameOptionsHeader,
       createRequestStore(oneApp, { useBodyForBuildingTheInitialState: true }),
       createRequestHtmlFragment(oneApp),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
post parameters are available in `req.body` only when request `content-type` is `application/json`. There is no way to handle default encoding method.

## Description
Feature to enable form post with default encoding method `application/x-www-form-urlencoded`

## Motivation and Context
There is a need for the clients to use form post for sharing information on to the application. This feature is already available in lower version of one-app.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested it locally by posting parameters, we could verify all of the post parameters in `req.body`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
NA
<!--- Please describe how your changes impacts developers using One App. -->
