### PR TITLE
fix(pwa): cache only responses with a 200 status

### DIFF
--- a/__tests__/integration/one-app.spec.js
+++ b/__tests__/integration/one-app.spec.js
@@ -992,7 +992,7 @@ describe('Tests that require Docker setup', () => {
 
               await browser.url(`${appAtTestUrls.browserUrl}/success`);
 
-              await waitFor(500);
+              await waitFor(5000);
 
               const cacheKeys = await browser.executeAsync(getCacheKeys);
               const cacheMap = new Map(await browser.executeAsync(getCacheEntries, cacheKeys));

--- a/__tests__/integration/one-app.spec.js
+++ b/__tests__/integration/one-app.spec.js
@@ -1014,7 +1014,7 @@ describe('Tests that require Docker setup', () => {
 
               await browser.url(`${appAtTestUrls.browserUrl}/success`);
 
-              await waitFor(500);
+              await waitFor(5000);
 
               const holocronModuleMap = readModuleMap();
               const cacheKeys = await browser.executeAsync(getCacheKeys);

--- a/src/client/service-worker/events/utility.js
+++ b/src/client/service-worker/events/utility.js
@@ -127,7 +127,12 @@ export function fetchCacheResource(event, meta) {
   return match(event.request.clone(), { cacheName: meta.cacheName })
     .then(
       (cachedResponse) => cachedResponse
-      || fetch(event.request.clone()).then(setCacheResource(event, meta))
+      || fetch(event.request.clone()).then((response) => {
+        if (response.status === 200) {
+          return setCacheResource(event, meta)(response);
+        }
+        return response;
+      })
     )
     .then(invalidateCacheResource(event, meta));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Cache only responses with a status of 200.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

One App should not cache responses that are not a 200.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Unit test

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
