### PR TITLE
fix(requestLog): only log on close

### DIFF
--- a/__tests__/server/utils/logging/__snapshots__/serverMiddleware.spec.js.snap
+++ b/__tests__/server/utils/logging/__snapshots__/serverMiddleware.spec.js.snap
@@ -1,38 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`serverMiddleware logs the request & response when the response cannot finish 1`] = `
-Array [
-  Object {
-    "request": Object {
-      "address": Object {
-        "uri": "https://example.com/resource",
-      },
-      "direction": "in",
-      "metaData": Object {
-        "correlationId": "123",
-        "forwarded": null,
-        "forwardedFor": null,
-        "host": "example.com",
-        "locale": undefined,
-        "location": undefined,
-        "method": "GET",
-        "referrer": "https://example.com/other-place",
-        "userAgent": "Browser/8.0 (compatible; WXYZ 100.0; Doors LQ 81.4; Boat/1.0)",
-      },
-      "protocol": "https",
-      "statusCode": undefined,
-      "statusText": undefined,
-      "timings": Object {
-        "duration": 12,
-        "ttfb": 0,
-      },
-    },
-    "type": "request",
-  },
-]
-`;
-
-exports[`serverMiddleware logs the request & response when the response finishes 1`] = `
+exports[`serverMiddleware logs the request & response when the response closes 1`] = `
 Array [
   Object {
     "request": Object {

--- a/__tests__/server/utils/logging/serverMiddleware.spec.js
+++ b/__tests__/server/utils/logging/serverMiddleware.spec.js
@@ -94,16 +94,7 @@ describe('serverMiddleware', () => {
     expect(startTimer).toHaveBeenCalledWith(res);
   });
 
-  it('logs the request & response when the response finishes', () => {
-    const { req, res, next } = createReqResNext();
-    logger.info.mockClear();
-    serverMiddleware(req, res, next);
-    findMockCallForEvent(res, 'finish')();
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    expect(logger.info.mock.calls[0]).toMatchSnapshot();
-  });
-
-  it('logs the request & response when the response cannot finish', () => {
+  it('logs the request & response when the response closes', () => {
     const { req, res, next } = createReqResNext();
     logger.info.mockClear();
     serverMiddleware(req, res, next);
@@ -120,7 +111,7 @@ describe('serverMiddleware', () => {
         .mockImplementationOnce(() => 56)
         .mockImplementationOnce(() => 34);
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.timings).toHaveProperty('ttfb', 22);
@@ -133,7 +124,7 @@ describe('serverMiddleware', () => {
         .mockImplementationOnce(() => undefined)
         .mockImplementationOnce(() => undefined);
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.timings).toHaveProperty('ttfb', null);
@@ -145,7 +136,7 @@ describe('serverMiddleware', () => {
       req.headers.host = expected;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('host', expected);
@@ -156,7 +147,7 @@ describe('serverMiddleware', () => {
       delete req.headers.host;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('host', null);
@@ -169,7 +160,7 @@ describe('serverMiddleware', () => {
       delete req.headers.referer;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('referrer', expected);
@@ -182,7 +173,7 @@ describe('serverMiddleware', () => {
       req.headers.referer = expected;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('referrer', expected);
@@ -194,7 +185,7 @@ describe('serverMiddleware', () => {
       delete req.headers.referer;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('referrer', null);
@@ -206,7 +197,7 @@ describe('serverMiddleware', () => {
       req.headers['user-agent'] = expected;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('userAgent', expected);
@@ -217,7 +208,7 @@ describe('serverMiddleware', () => {
       delete req.headers['user-agent'];
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('userAgent', null);
@@ -229,7 +220,7 @@ describe('serverMiddleware', () => {
       res.privateHeaderStore.location = expected;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('location', expected);
@@ -240,7 +231,7 @@ describe('serverMiddleware', () => {
       delete res.privateHeaderStore.location;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('location', undefined);
@@ -252,7 +243,7 @@ describe('serverMiddleware', () => {
       req.headers.forwarded = expected;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('forwarded', expected);
@@ -263,7 +254,7 @@ describe('serverMiddleware', () => {
       delete req.headers.forwarded;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('forwarded', null);
@@ -275,7 +266,7 @@ describe('serverMiddleware', () => {
       req.headers['x-forwarded-for'] = expected;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('forwardedFor', expected);
@@ -286,7 +277,7 @@ describe('serverMiddleware', () => {
       delete req.headers['x-forwarded-for'];
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('forwardedFor', null);
@@ -298,7 +289,7 @@ describe('serverMiddleware', () => {
       req.store = { getState: () => fromJS({ intl: fromJS({ activeLocale: expected }) }) };
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('locale', expected);
@@ -309,7 +300,7 @@ describe('serverMiddleware', () => {
       delete req.store;
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       const entry = logger.info.mock.calls[0][0];
       expect(entry.request.metaData).toHaveProperty('locale', undefined);
@@ -329,7 +320,7 @@ describe('serverMiddleware', () => {
       const { req, res, next } = createReqResNext();
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       expect(customConfigureRequestLog.mock.calls[0][0].req).toEqual(req);
       expect(customConfigureRequestLog.mock.calls[0][0].res).toEqual(res);
@@ -342,7 +333,7 @@ describe('serverMiddleware', () => {
       const { req, res, next } = createReqResNext();
       logger.info.mockClear();
       serverMiddleware(req, res, next);
-      findMockCallForEvent(res, 'finish')();
+      findMockCallForEvent(res, 'close')();
       expect(logger.info).toHaveBeenCalledTimes(1);
       expect(customConfigureRequestLog).not.toHaveBeenCalled();
     });

--- a/src/server/utils/logging/serverMiddleware.js
+++ b/src/server/utils/logging/serverMiddleware.js
@@ -102,8 +102,6 @@ export const setConfigureRequestLog = (newConfigureRequestLog = passThrough) => 
 export default function serverMiddleware(req, res, next) {
   startTimer(req);
   monkeypatches.attachSpy(res, 'writeHead', () => startTimer(res));
-  res.on('finish', () => logClientRequest(req, res));
-  res.on('close', () => logClientRequest(req, res)); // TODO: mention the different status?
-
+  res.on('close', () => logClientRequest(req, res));
   setImmediate(next);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix duplicate request logs. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Every request is currently being logged twice because as of Node 12 the 'close' event is fired in every request regardless. 

> Indicates that the the response is completed, or its underlying connection was terminated prematurely (before the response completion).

https://nodejs.org/docs/latest-v12.x/api/http.html#http_event_close_1

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests and locally by watching for duplicate request logs

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
