### PR TITLE
fix(helmet): fixes race condition with react-helmet

### DIFF
--- a/__tests__/client/__snapshots__/prerender.spec.js.snap
+++ b/__tests__/client/__snapshots__/prerender.spec.js.snap
@@ -1,22 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`moveHelmetScripts should only move scripts that were injected by react-helmet, ignoring others: helmet scripts 1`] = `
-NodeList [
-  <script
-    data-react-helmet="true"
-    src="hello.js"
-  />,
-  <script
-    data-react-helmet="true"
-    src="world.js"
-  />,
-  <script
-    data-react-helmet="true"
-    src="baz.js"
-  />,
-]
-`;
-
 exports[`moveHelmetScripts should only move scripts that were injected by react-helmet, ignoring others: non-helmet scripts 1`] = `
 NodeList [
   <script
@@ -24,6 +7,15 @@ NodeList [
   />,
   <script
     src="bar.js"
+  />,
+]
+`;
+
+exports[`moveHelmetScripts should remove helmet scripts from the body and only append helmet scripts to the head if react-helmet has not already injected them: head helmet scripts 1`] = `
+Array [
+  <script
+    data-react-helmet="true"
+    src="hello.js"
   />,
 ]
 `;

--- a/__tests__/client/prerender.spec.js
+++ b/__tests__/client/prerender.spec.js
@@ -167,7 +167,21 @@ describe('moveHelmetScripts', () => {
     document.addEventListener.mock.calls[0][1]();
 
     expect(document.querySelectorAll('body script')).toMatchSnapshot('non-helmet scripts');
-    expect(document.querySelectorAll('head script')).toMatchSnapshot('helmet scripts');
+  });
+
+  it('should remove helmet scripts from the body and only append helmet scripts to the head if react-helmet has not already injected them', () => {
+    const scriptForBody = createScript({ src: 'hello.js', helmet: true });
+    const scriptForHead = createScript({ src: 'hello.js', helmet: true });
+
+    document.body.appendChild(scriptForBody);
+    document.head.appendChild(scriptForHead);
+
+    moveHelmetScripts();
+    document.addEventListener.mock.calls[0][1]();
+    const scriptsFromHead = [...document.head.querySelectorAll('script')];
+    expect([...document.body.querySelectorAll('script')].length).toEqual(0);
+    expect(scriptsFromHead).toMatchSnapshot('head helmet scripts');
+    expect(scriptsFromHead.length).toEqual(1);
   });
 
   it('should not expect NodeList to have forEach due to IE', () => {

--- a/src/client/prerender.js
+++ b/src/client/prerender.js
@@ -46,9 +46,16 @@ export function loadPrerenderScripts(initialState) {
 
 export function moveHelmetScripts() {
   document.addEventListener('DOMContentLoaded', () => {
-    const helmetScripts = [...document.querySelectorAll('script[data-react-helmet]')];
-    helmetScripts.forEach((script) => document.body.removeChild(script));
-    helmetScripts.forEach((script) => document.head.appendChild(script));
+    const headHelmetScripts = [...document.head.querySelectorAll('script[data-react-helmet]')];
+    const bodyHelmetScripts = [...document.body.querySelectorAll('script[data-react-helmet]')];
+
+    bodyHelmetScripts.forEach((script) => document.body.removeChild(script));
+
+    // If the helmet scripts exist in the head then we can assume that the body
+    // scripts were already added by react-helmet
+    if (headHelmetScripts.length === 0) {
+      bodyHelmetScripts.forEach((script) => document.head.appendChild(script));
+    }
   });
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I'm proposing that when One App runs `initClient`  that it only remove helmet scripts from the body and will no longer append those scripts to the head of the html doc. Appending the helmet scripts to the head will be done by `Helmet`, because `Helmet` will add the scripts to the head whether it runs before or after `moveHelmetScripts`.

## Description
<!--- Describe your changes in detail -->
This PR changes `moveHelmetScripts` so that 1) it only queries the DOM for helmet scripts in the body rather than in the entire document, 2) no longer appends scripts to the head. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When One App middleware runs `sendHtml` on the server and creates an html doc it appends helmet scripts from the request to the html body. When the app is initialized on the client, the `moveHelmetScripts` function is invoked and it retrieves all scripts in the html doc, removes them from the body and adds them to the head.

The problem is that by the time this runs, it is possible for the `Helmet` component from `react-helmet` to have appended scripts to the head of the html doc. That duplicates the helmet scripts and will cause `moveHelmetScripts` to throw an error because it will try to remove all scripts it finds from the body without checking if they were found in the body. 

There are 2 scenarios I've found where Helmet appends scripts before `moveHelmetScripts` runs: 
1) When many modules are loaded on the page (race condition), `moveHelmetScripts` is firing after `Helmet` appends the scripts to the head. This seems to be due to the fact that it's invoked in an event listener waiting for `DOMContentLoaded` that can sometimes run after`react-helmet` updates the DOM (which is invoked in a componentWillMount lifecycle function). After `Helmet` appends scripts to the head, then `moveHelmetScripts` runs and grabs scripts from the body and the head. It will attempt to remove the head scripts from the body and then throws the error: `Uncaught DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

2) The second scenario when `moveHelmetScripts` throws an error is when a dev wants `react-helmet` to update the DOM ASAP and passes `defer={false}` to `Helmet`. https://github.com/nfl/react-helmet#readme
If defer is false, then `Helmet` appends scripts to the head much earlier and will always cause `moveHelmetScript` to error if scripts have been added to the body on the server. Here is an example with the sample module, `ssr-frank` adding one helmet script with `react-helmet`: 
```jsx
<Helmet
  defer={false}
  onChangeClientState={(newState, addedTags, removedTags) => console.log('react-helmet - onChangeClientState', newState, 'added', addedTags, 'removed', removedTags)}
  script={[
      {
        type: 'application/ld+json',
        innerHTML: JSON.stringify({ '@context': 'https://schema.org' }),
       }
  ]}
/>
```
You can see that the script is duplicated and the function throws an error: 
<img width="1678" alt="Screen Shot 2021-07-16 at 3 38 17 PM" src="https://user-images.githubusercontent.com/33100935/126002116-c36b5405-4537-416b-a469-6ff3b6d90fba.png">

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran this using a `demo` route with one module and on a working route with multiple modules without passing the `defer` prop (so it's `true`) and passed it with the value `false`.

If we run `ssr-frank` with the following `Helmet` code added and the `append` command removed, you see that everything looks fine. `moveHelmetScripts` will remove the one script off the html `body` and then `react-helmet` will add the one script to the head: 
<img width="1682" alt="Screen Shot 2021-07-16 at 3 40 39 PM" src="https://user-images.githubusercontent.com/33100935/126001462-f7e249da-4a34-4e3a-b57e-f8ff7fe70800.png">

If I pass `defer={false}` to `Helmet`, then the script will be added to the head before `moveHelmetScripts` runs. Everything works: 
<img width="1679" alt="Screen Shot 2021-07-16 at 3 32 24 PM" src="https://user-images.githubusercontent.com/33100935/126001572-257753e2-e95a-4de7-8e50-aee338c2f6e3.png">


<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This shouldn't affect any other areas of the code.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
This should have not noticeable impact on current users who do not see the DOM exception error. It will resolve that error for users who are currently seeing it and it will allow developers using One App to instruct `Helmet` to update the DOM earlier. 