### PR TITLE
feat(externals): added flag to not throw if externals versions have a mismatch

### DIFF
--- a/__tests__/server/utils/onModuleLoad.spec.jsx
+++ b/__tests__/server/utils/onModuleLoad.spec.jsx
@@ -253,6 +253,20 @@ describe('onModuleLoad', () => {
     expect(() => onModuleLoad({ module: { [CONFIGURATION_KEY]: configuration, [META_DATA_KEY]: { version: '1.0.11' } }, moduleName: 'my-awesome-module' })).toThrowErrorMatchingSnapshot();
   });
 
+  it('logs a warning if the root module provides an incompatible version of a required external and DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS is set to true', () => {
+    process.env.DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS = true;
+    RootModule[CONFIGURATION_KEY].providedExternals = {
+      'dep-a': { version: '2.1.0', module: () => 0 },
+    };
+    const configuration = {
+      requiredExternals: {
+        'dep-a': '^2.1.1',
+      },
+    };
+    expect(() => onModuleLoad({ module: { [CONFIGURATION_KEY]: configuration, [META_DATA_KEY]: { version: '1.0.10' } }, moduleName: 'my-awesome-module' })).not.toThrow();
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps track of the externals a module is using', () => {
     RootModule[CONFIGURATION_KEY] = {
       providedExternals: {

--- a/docs/api/server/Environment-Variables.md
+++ b/docs/api/server/Environment-Variables.md
@@ -33,6 +33,7 @@ One App can be configured via Environment Variables:
   * [`NODE_ENV`](#node_env) ⚠️
   * [`ONE_CLIENT_ROOT_MODULE_NAME`](#one_client_root_module_name) ⚠️
   * [`ONE_CONFIG_ENV`](#one_config_env) ⚠️
+  * [`DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS`](#dangerously_accept_breaking_externals)
 * Server Settings
   * [`HOLOCRON_SERVER_MAX_MODULES_RETRY`](#holocron_server_max_modules_retry)
   * [`HOLOCRON_SERVER_MAX_SIM_MODULES_FETCH`](#holocron_server_max_sim_modules_fetch)
@@ -509,6 +510,31 @@ ONE_CONFIG_ENV=staging
 ```bash
 ONE_CONFIG_ENV=undefined
 ```
+
+## `DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS`
+
+**Runs In**
+* ✅ Production
+* ✅ Development
+
+If set to `true`, one-app will not throw an error when externals provided by the root module and externals required by child modules have conflicting semver ranges.
+This flag is meant to ease the transition to newer versions of externals. It should not be kept on for long as mismatching versions of packages can cause unexpected issues.
+
+**Shape**
+```bash
+DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS=true
+```
+
+**Example**
+```bash
+DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS=true
+```
+
+**Default Value**
+```bash
+DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS=undefined
+```
+
 
 ## `ONE_ENABLE_POST_TO_MODULE_ROUTES`
 

--- a/src/server/utils/onModuleLoad.js
+++ b/src/server/utils/onModuleLoad.js
@@ -147,7 +147,11 @@ export default function onModuleLoad({
       if (!providedExternal) {
         messages.push(`External '${externalName}' is required by ${moduleName}, but is not provided by the root module`);
       } else if (!semver.satisfies(providedExternal.version, requestedExternalVersion)) {
-        messages.push(`${externalName}@${requestedExternalVersion} is required by ${moduleName}, but the root module provides ${providedExternal.version}`);
+        if (process.env.DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS) {
+          console.warn(`${externalName}@${requestedExternalVersion} is required by ${moduleName}, but the root module provides ${providedExternal.version}`);
+        } else {
+          messages.push(`${externalName}@${requestedExternalVersion} is required by ${moduleName}, but the root module provides ${providedExternal.version}`);
+        }
       }
     });
 


### PR DESCRIPTION
## Description
Adds a new flag, DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS, that when set `true`, will log a warning instead of throwing an error whenever a mismatch in version for externals is detected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When upgrading versions of `providedExternals` set by your route module, it can be frustrating because one-app will fail to start up because it throws an error when mismatching external versions are found. If the app is already running, module map polling will fail.

The DANGEROUSLY_ACCEPT_BREAKING_EXTERNALS flag will prevent this from happening by logging a warning instead of throwing an error.

This is a dangerous flag to set because mismatching versions can cause unexpected behaviors for modules, and should only be used during a transition of external versions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit tested

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
