### PR TITLE
feat(routes): childRoutes are not required for root module

### DIFF
--- a/__tests__/universal/routes.spec.jsx
+++ b/__tests__/universal/routes.spec.jsx
@@ -28,6 +28,9 @@ jest.mock('@americanexpress/one-app-ducks/lib/errorReporting', () => ({
   })),
 }));
 
+let mockHasChildRoutesValue;
+jest.mock('../../src/universal/utils/hasChildRoutes', () => () => mockHasChildRoutesValue);
+
 describe('routes', () => {
   const store = {
     getState: () => fromJS({
@@ -44,16 +47,36 @@ describe('routes', () => {
 
   beforeEach(() => jest.clearAllMocks());
 
-  it('should set up the root module route first', () => {
-    const RootRoute = createRoutes(store)[0];
-    expect(ReactTestUtils.isElement(RootRoute)).toBe(true);
-    expect(RootRoute.props).toEqual({ moduleName: 'fakeRootModule', store });
+  describe('RootModule without childroutes', () => {
+    it('should add a path on the root route', () => {
+      mockHasChildRoutesValue = false;
+      const RootRoute = createRoutes(store)[0];
+      expect(RootRoute.props.path).toBe('/');
+    });
+
+    it('should return RootRoute props with path', () => {
+      mockHasChildRoutesValue = false;
+      const RootRoute = createRoutes(store)[0];
+      expect(ReactTestUtils.isElement(RootRoute)).toBe(true);
+      expect(RootRoute.props).toEqual({ moduleName: 'fakeRootModule', path: '/', store });
+    });
   });
 
-  it('should not define a path on the root module', () => {
-    const RootRoute = createRoutes(store)[0];
-    expect(RootRoute.props.path).toBe(undefined);
+  describe('RootModule with childroutes', () => {
+    it('path should be undefined', () => {
+      mockHasChildRoutesValue = true;
+      const RootRoute = createRoutes(store)[0];
+      expect(RootRoute.props.path).toBe(undefined);
+    });
+
+    it('should return RootRoute props without path', () => {
+      mockHasChildRoutesValue = true;
+      const RootRoute = createRoutes(store)[0];
+      expect(ReactTestUtils.isElement(RootRoute)).toBe(true);
+      expect(RootRoute.props).toEqual({ moduleName: 'fakeRootModule', store });
+    });
   });
+
 
   it('should set up a default 404', () => {
     const NotFoundRoute = createRoutes(store)[1];

--- a/__tests__/universal/utils/hasChildRoutes.spec.js
+++ b/__tests__/universal/utils/hasChildRoutes.spec.js
@@ -1,0 +1,11 @@
+import hasChildRoutes from '../../../src/universal/utils/hasChildRoutes';
+
+it('hasChildRoutes returns false', () => {
+  [undefined, null, '', {}].forEach((value) => {
+    expect(hasChildRoutes(value)).toBe(false);
+  });
+});
+
+it('hasChildRoutes returns true', () => {
+  expect(hasChildRoutes({ childRoutes: [] })).toBe(true);
+});

--- a/src/universal/routes.jsx
+++ b/src/universal/routes.jsx
@@ -22,11 +22,17 @@ import React from 'react';
 import ModuleRoute from 'holocron-module-route';
 import { Route } from '@americanexpress/one-app-router';
 import { applicationError, clearError } from '@americanexpress/one-app-ducks';
+import { getModule } from 'holocron';
+import hasChildRoutes from './utils/hasChildRoutes';
 
 const createRoutes = (store) => {
   const rootModuleName = store.getState().getIn(['config', 'rootModuleName']);
+  const RootModule = getModule(rootModuleName);
+  const rootHasChildRoutes = hasChildRoutes(RootModule);
+
   return [
-    <ModuleRoute moduleName={rootModuleName} store={store} />,
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <ModuleRoute moduleName={rootModuleName} store={store} {...(!rootHasChildRoutes && { path: '/' })} />,
     <Route
       path="*"
       component={() => 'Not found'}

--- a/src/universal/utils/hasChildRoutes.js
+++ b/src/universal/utils/hasChildRoutes.js
@@ -1,0 +1,3 @@
+const hasChildRoutes = (module) => (module ? !!module.childRoutes : false);
+
+export default hasChildRoutes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
childRoutes are not required for root modules.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran one-app server locally with root module, with and without child modules.

Test cases are written for new files and files changed.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Root modules no longer requires childRoutes. If childRoutes are not provided, path is added, which will render root component.
