### PR TITLE
docs(overview): fix links in Getting-Started.md

### DIFF
--- a/docs/overview/Getting-Started.md
+++ b/docs/overview/Getting-Started.md
@@ -62,7 +62,7 @@ about your new module before it is generated.
 - Select "yes" for `internationalization`
 
 > Read more about [`parrot-middleware`](parrot-middleware)
-> and [`internationalization`](../guides/internationalizing-your-module.md)
+> and [`internationalization`](../guides/Internationalizing-Your-Module.md)
 
 Once the root module is generated we will be able to start developing with One App.
 As we continue, we will eventually create a child Holocron module for us to use -
@@ -147,15 +147,15 @@ multiple local modules when it's configured to accept them.
 >
 > **Development**
 >
-> [Run One App Locally](../guides/running-one-app-locally.md)
+> [Run One App Locally](../guides/Running-One-App-Locally.md)
 >
-> [Mocking API Calls](../guides/mocking-api-calls.md)
+> [Mocking API Calls](../guides/Mocking-Api-Calls.md)
 >
 > **Production**
 >
-> [Running In Production](../guides/running-in-production.md)
+> [Running In Production](../guides/Running-In-Production.md)
 >
-> [Publishing Modules](../guides/publishing-modules.md)
+> [Publishing Modules](../guides/Publishing-Modules.md)
 >
 > ##### Packages
 >
@@ -207,7 +207,7 @@ export default function MyModule() {
 >
 > **Guides**
 >
-> [Adding Styles Recipe](../guides/adding-styles)
+> [Adding Styles Recipe](../guides/Adding-Styles.md)
 
 ### Creating Routes
 
@@ -254,15 +254,15 @@ if that is all that's needed.
 >
 > **API**
 >
-> [Routing](../api/modules/routing.md)
+> [Routing](../api/modules/Routing.md)
 >
-> [Loading Modules](../api/modules/loading-modules.md)
+> [Loading Modules](../api/modules/Loading-Modules.md)
 >
 > **Guides**
 >
-> [Module Composition](../guides/module-composition.md)
+> [Module Composition](../guides/Module-Composition.md)
 >
-> [Code Splitting Using Holocron](../guides/code-splitting-using-holocron.md)
+> [Code Splitting Using Holocron](../guides/Code-Splitting-Using-Holocron.md)
 >
 > ##### Packages
 >
@@ -324,17 +324,17 @@ learn about in the next section.
 >
 > **API**
 >
-> [Loading Data](../api/modules/loading-data.md)
+> [Loading Data](../api/modules/Loading-Data.md)
 >
-> [State Management](../api/modules/state-management.md)
+> [State Management](../api/modules/State-Management.md)
 >
 > **Guides**
 >
-> [Making An API Call](../guides/making-an-api-call.md)
+> [Making An API Call](../guides/Making-An-Api-Call.md)
 >
-> [Enabling Server Side Render](../guides/enabling-serverside-rendering.md)
+> [Enabling Server Side Render](../guides/Enabling-Serverside-Rendering.md)
 >
-> [Internationalization](../guides/internationalizing-your-module.md)
+> [Internationalization](../guides/Internationalizing-Your-Module.md)
 >
 > ##### Packages
 >
@@ -350,7 +350,7 @@ ___
 
 **Up Next**
 
-Check out the [Configuration guide](./configuration.md) to grasp
+Check out the [Configuration guide](./Configuration.md) to grasp
 how we can use environment variables and Holocron module app
 configuration to cater to our needs as well as utilize features
 in One App.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I've updated the links on Getting-Started.md from lower-case paths to corresponding upper-case paths to match the doc files.

## Motivation and Context
GitHub wasn't happy with the links that did not match the exact case of the markdown file names. These links were showing up as 404 pages.

## How Has This Been Tested?
I've verified the links on this doc on my branch.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
None
