### PR TITLE
fix(csp): remove script nonce if inline scripts are disabled

### DIFF
--- a/__tests__/server/middleware/csp.spec.js
+++ b/__tests__/server/middleware/csp.spec.js
@@ -127,7 +127,7 @@ describe('csp', () => {
       const headers = res._getHeaders();
       const { scriptNonce } = res;
       expect(headers).toHaveProperty('content-security-policy');
-      expect(headers['content-security-policy'].search(scriptNonce)).not.toEqual(-1);
+      expect(headers['content-security-policy'].includes(scriptNonce)).toBe(true);
     });
 
     it('does not set the script nonce if this has been disabled in development', () => {
@@ -139,11 +139,7 @@ describe('csp', () => {
       const { updateCSP } = requiredCsp;
       updateCSP("default-src 'none'; script-src 'self';");
       cspMiddleware()(req, res, next);
-      // eslint-disable-next-line no-underscore-dangle
-      const headers = res._getHeaders();
-      const { scriptNonce } = res;
-      expect(headers).toHaveProperty('content-security-policy');
-      expect(headers['content-security-policy'].search(scriptNonce)).toEqual(-1);
+      expect(res.scriptNonce).toBeUndefined();
     });
   });
 

--- a/src/server/middleware/csp.js
+++ b/src/server/middleware/csp.js
@@ -66,14 +66,14 @@ const csp = () => (req, res, next) => {
     if (process.env.ONE_CSP_ALLOW_INLINE_SCRIPTS === 'true') {
       updatedScriptSrc = insertSource(policy, 'script-src', developmentAdditions);
     } else {
+      res.scriptNonce = scriptNonce;
       updatedScriptSrc = insertSource(policy, 'script-src', `'nonce-${scriptNonce}' ${developmentAdditions}`);
     }
     updatedPolicy = insertSource(updatedScriptSrc, 'connect-src', developmentAdditions);
   } else {
+    res.scriptNonce = scriptNonce;
     updatedPolicy = insertSource(policy, 'script-src', `'nonce-${scriptNonce}'`);
   }
-
-  res.scriptNonce = scriptNonce;
 
   if (process.env.ONE_DANGEROUSLY_DISABLE_CSP !== 'true') {
     res.setHeader('Content-Security-Policy', updatedPolicy);


### PR DESCRIPTION
The changes made in #636 are breaking due to the script nonce being added to the initial response, even if the environment variable is enabled and it is being correctly suppressed from the CSP header.

## Description
The middleware that prepares the HTML response already includes a check to not apply the script nonce if it isn't populated, so we just need to ensure that the nonce is never populated if inline scripts are enabled in dev, rather than simply suppressing it in the header. I've moved the code applying up slightly inside the conditional blocks that run either in production, or if the env var isn't set.

I tested this feature using a root module, and it only occurs if the app's root module is a prod build and not being served, and so overlooked this scenario.

## Motivation and Context
Bugfix for #636

This bug only occurs if you aren't serving your app's root module. In OneApp 5.13 you can avoid it by serving your root module.

## How Has This Been Tested?
I tested it with a child module this time, in Firefox 97.0.2.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
Feature added in #636 works in all scenarios
