### PR TITLE
fix(addFrameOptions): strict csp domain now matches

### DIFF
--- a/__tests__/server/middleware/addFrameOptionsHeader.spec.js
+++ b/__tests__/server/middleware/addFrameOptionsHeader.spec.js
@@ -18,7 +18,7 @@ import addFrameOptionsHeader from '../../../src/server/middleware/addFrameOption
 
 jest.mock('../../../src/server/middleware/csp', () => ({
   getCSP: () => ({
-    'frame-ancestors': ['*.example.com'],
+    'frame-ancestors': ['valid.example.com'],
   }),
 }));
 
@@ -36,14 +36,14 @@ describe('addFrameOptionsHeader', () => {
 
   it('should add X-Frame-Options ALLOW-FROM header on approved ancestor', () => {
     req = {
-      get: jest.fn(() => 'https://external.example.com/embedded'),
+      get: jest.fn(() => 'https://valid.example.com/embedded'),
     };
     addFrameOptionsHeader(req, res, next);
 
     expect(req.get).toHaveBeenCalledWith('Referer');
     expect(res.set).toBeCalledWith(
       'X-Frame-Options',
-      'ALLOW-FROM https://external.example.com/embedded'
+      'ALLOW-FROM https://valid.example.com/embedded'
     );
     expect(next).toBeCalled();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@americanexpress/one-app",
-      "version": "5.13.0",
+      "version": "5.13.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/server/middleware/addFrameOptionsHeader.js
+++ b/src/server/middleware/addFrameOptionsHeader.js
@@ -21,8 +21,8 @@ export default function addFrameOptionsHeader(req, res, next) {
   const referer = req.get('Referer');
 
   const frameAncestorDomains = getCSP()['frame-ancestors'];
-
-  const matchedDomain = frameAncestorDomains && frameAncestorDomains.find((domain) => matcher.isMatch(referer, `${domain}/*`)
+  const trimmedReferrer = referer && referer.replace('https://', '');
+  const matchedDomain = frameAncestorDomains && frameAncestorDomains.find((domain) => matcher.isMatch(trimmedReferrer, `${domain}/*`)
   );
 
   if (matchedDomain) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
remove "https://" from referrer when looking for frame-ancestors match

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
test suide

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
