### PR TITLE
fix(env): don't require ONE_ENABLE_POST_TO_MODULE_ROUTES to be set

### DIFF
--- a/__tests__/server/config/env/runTime.spec.js
+++ b/__tests__/server/config/env/runTime.spec.js
@@ -457,9 +457,11 @@ describe('runTime', () => {
       expect(enablePostToModuleRoutes.defaultValue).toBe('false');
     });
 
-    it('should normalize the value to lower case', () => {
-      expect(enablePostToModuleRoutes.normalize('Value')).toBe('value');
-      expect(enablePostToModuleRoutes.normalize('VALUE')).toBe('value');
+    it('should normalize the value to be either true or false', () => {
+      expect(enablePostToModuleRoutes.normalize('Value')).toBe('true');
+      expect(enablePostToModuleRoutes.normalize('VALUE')).toBe('true');
+      expect(enablePostToModuleRoutes.normalize('true')).toBe('true');
+      expect(enablePostToModuleRoutes.normalize('FALSE')).toBe('false');
     });
 
     it('should pass validation when value is "true" or "false"', () => {
@@ -492,12 +494,6 @@ describe('runTime', () => {
     it('should pass validation when input is parseable by bytes util', () => {
       process.env.ONE_ENABLE_POST_TO_MODULE_ROUTES = true;
       expect(() => postRequestMaxPayload.validate('20kb')).not.toThrow();
-    });
-
-    it('should fail validation when POSTing is not enabled', () => {
-      expect(() => postRequestMaxPayload.validate('20kb')).toThrowErrorMatchingInlineSnapshot(
-        '"ONE_ENABLE_POST_TO_MODULE_ROUTES must be \\"true\\" to configure max POST payload."'
-      );
     });
   });
 });

--- a/docs/api/server/Environment-Variables.md
+++ b/docs/api/server/Environment-Variables.md
@@ -614,7 +614,7 @@ ONE_ENABLE_POST_TO_MODULE_ROUTES=false
 * ✅ Production
 * ✅ Development
 
-Maximum payload allowed in POST requests. `ONE_ENABLE_POST_TO_MODULE_ROUTES` must be true to configure this.
+Maximum payload allowed in POST requests. Has no effect unless `ONE_ENABLE_POST_TO_MODULE_ROUTES` is set to true.
 
 **Shape**
 ```bash

--- a/src/server/config/env/runTime.js
+++ b/src/server/config/env/runTime.js
@@ -213,7 +213,12 @@ const runTime = [
   {
     name: 'ONE_ENABLE_POST_TO_MODULE_ROUTES',
     defaultValue: 'false',
-    normalize: (input) => input.toLowerCase(),
+    normalize: (input) => {
+      if (input.toLowerCase() === 'false') {
+        return 'false';
+      }
+      return `${!!input}`;
+    },
     validate: (input) => {
       if (input !== 'true' && input !== 'false') {
         throw new Error(`Expected "${input}" to be "true" or "false"`);
@@ -225,10 +230,6 @@ const runTime = [
     name: 'ONE_MAX_POST_REQUEST_PAYLOAD',
     defaultValue: '15kb',
     validate: (input) => {
-      if (process.env.ONE_ENABLE_POST_TO_MODULE_ROUTES !== 'true') {
-        throw new Error('ONE_ENABLE_POST_TO_MODULE_ROUTES must be "true" to configure max POST payload.');
-      }
-
       const parsed = bytes.parse(input);
 
       if (parsed === null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ONE_ENABLE_POST_TO_MODULE_ROUTES was defaulted to `false`. 
ONE_MAX_POST_REQUEST_PAYLOAD required ONE_ENABLE_POST_TO_MODULE_ROUTES to be true, or else it threw an error. 

So on startup of one-app, it would fail to start unless you set ONE_ENABLE_POST_TO_MODULE_ROUTES to true.

ALSO

ONE_ENABLE_POST_TO_MODULE_ROUTES used to be true as long as any value was set. This was changed to require it to be either `true` or `false`, which is a breaking change. This PR reverts that.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Broke one-app

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
