### PR TITLE
chore(workflow): allow control of docker meta tag

### DIFF
--- a/.github/workflows/release-step-3_automatic_prepare-docker-tags.yml
+++ b/.github/workflows/release-step-3_automatic_prepare-docker-tags.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Normalize meta tag
         id: set_docker_meta_tag
         run: |
-          # if a meta tag was specified this was a menual build
+          # if a meta tag was specified this was a manual build
           if [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
           then
           echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}

--- a/.github/workflows/release-step-3_automatic_prepare-docker-tags.yml
+++ b/.github/workflows/release-step-3_automatic_prepare-docker-tags.yml
@@ -5,6 +5,14 @@ on:
     tag_version:
      description: 'Semantic Version'
      required: true
+    docker_meta_tag:
+     type: choice
+     options:
+      - do_not_tag
+      - latest
+      - next
+     description: When manually triggering a deployment, specify which meta tag such as `latest` should be used. `do_not_tag` will result in no meta tag being applied.
+     required: true
   push:
     tags:
       - '*'
@@ -30,6 +38,24 @@ jobs:
           echo ::set-output name=tagversion::${{ github.event.inputs.tag_version }}
           fi
           echo $tagversion
+      - name: Normalize meta tag
+        id: set_docker_meta_tag
+        run: |
+          # if a meta tag was specified this was a menual build
+          if [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
+          then
+          echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}
+          echo From manual run: ${{ github.event.inputs.docker_meta_tag }}
+          # if we are on the main branch, default to `latest`
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          then
+          echo ::set-output name=metatag::latest
+          echo For main branch: latest
+          # if we are not on the main branch, default to `do_not_tag`
+          else
+          echo ::set-output name=metatag::do_not_tag
+          echo For other branch: do_not_tag
+          fi
       - name: Check Tag Version
         run: |
           if [[ "${{ steps.set_tag_version.outputs.tagversion }}" == ""  ]]; then
@@ -54,6 +80,6 @@ jobs:
           repository: ${{ github.repository }}
           mediaType: '{"previews": ["everest"]}'
           event_type: "release-step-4_automatic_docker-prod-build-and-publish"
-          client_payload: '{"docker_tag_version": "${{ steps.set_docker_tag_version.outputs.dockertag }}"}'
+          client_payload: '{"docker_tag_version": "${{ steps.set_docker_tag_version.outputs.dockertag }}", "docker_meta_tag": "${{ steps.set_docker_meta_tag.outputs.metatag }}"}'
         env:
           GITHUB_TOKEN: ${{ secrets.PA_TOKEN }}

--- a/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
+++ b/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
@@ -52,7 +52,7 @@ jobs:
           then
           echo ::set-output name=metatag::${{ github.event.client_payload.docker_meta_tag }}
           echo From previous step: ${{ github.event.client_payload.docker_meta_tag }}
-          # if a meta tag was specified this was a menual build
+          # if a meta tag was specified this was a manual build
           elif [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
           then
           echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}

--- a/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
+++ b/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
@@ -76,11 +76,12 @@ jobs:
         run: docker build -t prod .
       - name: Tag Docker Images
         run: |
-          docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
           docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}.${{steps.set_docker_version.outputs.minor_version}}
           docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.docker_version}}
           if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
           then
+           # if we are not tagging `latest` or `next`, dont tag with the major either
+          docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
           docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_meta_tag.outputs.metatag }}
           fi
       - name: Push Docker Images
@@ -90,6 +91,7 @@ jobs:
           docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.docker_version}}
           if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
           then
+          docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
           docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_meta_tag.outputs.metatag }}
           fi
       - name: Trigger Development Image Publishing

--- a/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
+++ b/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
@@ -5,6 +5,14 @@ on:
     docker_tag_version:
      description: 'Semantic Version'
      required: true
+    docker_meta_tag:
+      type: choice
+      options:
+        - do_not_tag
+        - latest
+        - next
+      description: When manually triggering a deployment, specify which meta tag such as `latest` should be used. `do_not_tag` will result in no meta tag being applied.
+      required: true
   repository_dispatch:
     types: [release-step-4_automatic_docker-prod-build-and-publish]
 jobs:
@@ -36,6 +44,29 @@ jobs:
           echo ::set-output name=major_version::${MAJOR}
           echo ::set-output name=minor_version::${MINOR}
           fi
+      - name: Normalize meta tag
+        id: set_docker_meta_tag
+        run: |
+          # Always use the value from the last step if it is present
+          if [[ "${{ github.event.client_payload.docker_meta_tag }}" != "" ]]
+          then
+          echo ::set-output name=metatag::${{ github.event.client_payload.docker_meta_tag }}
+          echo From previous step: ${{ github.event.client_payload.docker_meta_tag }}
+          # if a meta tag was specified this was a menual build
+          elif [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
+          then
+          echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}
+          echo From manual run: ${{ github.event.inputs.docker_meta_tag }}
+          # if we are on the main branch, default to `latest`
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          then
+          echo ::set-output name=metatag::latest
+          echo For main branch: latest
+          # if we are not on the main branch, default to `do_not_tag`
+          else
+          echo ::set-output name=metatag::do_not_tag
+          echo For other branch: do_not_tag
+          fi
       - uses: actions/checkout@v2
         with:
           ref: "v${{ steps.set_docker_version.outputs.docker_version }}"
@@ -48,13 +79,19 @@ jobs:
           docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
           docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}.${{steps.set_docker_version.outputs.minor_version}}
           docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.docker_version}}
-          docker tag prod ${{ secrets.DOCKER_USER }}/one-app:latest
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
+          then
+          docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_meta_tag.outputs.metatag }}
+          fi
       - name: Push Docker Images
         run: |
           docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
           docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version}}
           docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.docker_version}}
-          docker push ${{ secrets.DOCKER_USER }}/one-app:latest
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
+          then
+          docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_meta_tag.outputs.metatag }}
+          fi
       - name: Trigger Development Image Publishing
         uses: octokit/request-action@v2.x
         id: dispatch_one_app_docker_dev_build
@@ -63,6 +100,6 @@ jobs:
           repository: ${{ github.repository }}
           mediaType: '{"previews": ["everest"]}'
           event_type: "release-step-5_automatic_docker-dev-build-and-publish"
-          client_payload: '{"docker_tag_version": "${{ steps.set_docker_version.outputs.docker_version }}","major_version":"${{ steps.set_docker_version.outputs.major_version}}","minor_version":"${{ steps.set_docker_version.outputs.minor_version}}"}'
+          client_payload: '{"docker_tag_version": "${{ steps.set_docker_version.outputs.docker_version }}","major_version":"${{ steps.set_docker_version.outputs.major_version}}","minor_version":"${{ steps.set_docker_version.outputs.minor_version}}"}, "docker_meta_tag": "${{ steps.set_docker_meta_tag.outputs.metatag }}"}'
         env:
           GITHUB_TOKEN: ${{ secrets.PA_TOKEN }}

--- a/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
+++ b/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
@@ -44,7 +44,7 @@ jobs:
           then
           echo ::set-output name=metatag::${{ github.event.client_payload.docker_meta_tag }}
           echo From previous step: ${{ github.event.client_payload.docker_meta_tag }}
-          # if a meta tag was specified this was a menual build
+          # if a meta tag was specified this was a manual build
           elif [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
           then
           echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}

--- a/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
+++ b/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
@@ -5,6 +5,14 @@ on:
     docker_tag_version:
      description: 'Semantic Version'
      required: true
+    docker_meta_tag:
+      type: choice
+      options:
+        - do_not_tag
+        - latest
+        - next
+      description: When manually triggering a deployment, specify which meta tag such as `latest` should be used. `do_not_tag` will result in no meta tag being applied.
+      required: true
   repository_dispatch:
     types: [release-step-5_automatic_docker-dev-build-and-publish]
 jobs:
@@ -28,6 +36,29 @@ jobs:
           echo ::set-output name=major_version::${MAJOR}
           echo ::set-output name=minor_version::${MINOR}
           fi
+      - name: Normalize meta tag
+        id: set_docker_meta_tag
+        run: |
+          # Always use the value from the last step if it is present
+          if [[ "${{ github.event.client_payload.docker_meta_tag }}" != "" ]]
+          then
+          echo ::set-output name=metatag::${{ github.event.client_payload.docker_meta_tag }}
+          echo From previous step: ${{ github.event.client_payload.docker_meta_tag }}
+          # if a meta tag was specified this was a menual build
+          elif [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
+          then
+          echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}
+          echo From manual run: ${{ github.event.inputs.docker_meta_tag }}
+          # if we are on the main branch, default to `latest`
+          elif [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          then
+          echo ::set-output name=metatag::latest
+          echo For main branch: latest
+          # if we are not on the main branch, default to `do_not_tag`
+          else
+          echo ::set-output name=metatag::do_not_tag
+          echo For other branch: do_not_tag
+          fi
       - name: Print docker version
         run:  |
           echo "tag: ${{ steps.set_docker_version.outputs.docker_version }}"
@@ -43,13 +74,19 @@ jobs:
           docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version }}
           docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version }}
           docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.docker_version }}
-          docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:latest
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
+          then
+          docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_meta_tag.outputs.metatag }}
+          fi
       - name: Push Docker Images
         run: |
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version }}
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.docker_version}}
-          docker push ${{ secrets.DOCKER_USER }}/one-app-dev:latest
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
+          then
+          docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_meta_tag.outputs.metatag }}
+          fi
       - name: Publish One App Statics
         uses: octokit/request-action@v2.x
         id: dispatch_publish_statics_npm

--- a/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
+++ b/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
@@ -71,20 +71,21 @@ jobs:
         run: docker build -t dev . --target=development
       - name: Tag Docker Images
         run: |
-          docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version }}
           docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version }}
           docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.docker_version }}
           if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
           then
+           # if we are not tagging `latest` or `next`, dont tag with the major either
+          docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version }}
           docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_meta_tag.outputs.metatag }}
           fi
       - name: Push Docker Images
         run: |
-          docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version }}
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.docker_version}}
           if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
           then
+          docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_meta_tag.outputs.metatag }}
           fi
       - name: Publish One App Statics

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,7 +53,9 @@ This process can be used to make ad hoc releases outside of wednesday release cy
 
 This should only be used as a last resort. Ensure that the tag being used references a valid release commit.
 
- 1. Manually run the [[Release step 3 | automatic] Prepare docker tags](https://github.com/americanexpress/one-app/actions/workflows/release-step-3_automatic_prepare-docker-tags.yml) workflow and provide a valid semantic release version of an existing tag which has not been released.
+1. Manually run the [[Release step 3 | automatic] Prepare docker tags](https://github.com/americanexpress/one-app/actions/workflows/release-step-3_automatic_prepare-docker-tags.yml) workflow:
+   1. Provide a valid semantic release version of an existing tag which has not been released.
+   2. Specify if this release should be tagged as `latest`, `next` or use `do_not_tag`(default) to add no meta tag
 
 ## FAQs
 


### PR DESCRIPTION
This PR allows control over the docker meta tag (such as `latest` `next` etc)

1. Three workflows (Release 3, 4, and 5) now accept a required choice of `latest`, `next`, or `do_not_tag`.
- Although Release 3 does not use this value, it will pass it to Release 4. Since Release 3 is the 'entrypoint' for releasing arbitrary tags, Release 3 must receive this value and pass it on.

2. The `Normalize meta tag` step of Release 3, 4, and 5 will determine the value, in this order:
- If the previous workflow passed in a value, that will be used
- If the user has specified a value, that will be used
- For automatic runs on the main branch, the value will be `latest`
- For automatic runs on any other branch the value will be `do_not_tag`

3. The value is used while tagging and pushing the docker image (present in Release 4 and 5 only)
- If the value is `do_not_tag`, the meta tag will be skipped (the image will still be tagged with the versions as normal)
- if the value is `do_not_tag`, the major version tag will also be skipped. The major version tag acts like a `latest in this major stream` tag, and so if we are not tagging `latest` we should not tag the major either.
- For any other run, the tag will take the value as specified in `Normalize meta tag`

4. The value is passed forward to the next workflow (present in Release 3 and 4 only)

- Since Release 6 has no use for the value, Release 5 does not need to pass it on

## How Has This Been Tested?
Running workflows in a fork of this repo, including reading the logs from `Normalize meta tag` and seeing the tag used at the tag step

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.