### PR TITLE
chore(workflows): only tag major and major.minor for latest

### DIFF
--- a/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
+++ b/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
@@ -76,22 +76,34 @@ jobs:
         run: docker build -t prod .
       - name: Tag Docker Images
         run: |
-          docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}.${{steps.set_docker_version.outputs.minor_version}}
+          # Always tag the exact version
           docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.docker_version}}
+
+          # Only tag with `<major>` and `<major>.<minor>` if we are tagging `latest`
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" == "latest" ]]
+          then
+          docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
+          docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}.${{steps.set_docker_version.outputs.minor_version}}
+          fi
+
+          # Finally tag with the requested meta tag
           if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
           then
-           # if we are not tagging `latest` or `next`, dont tag with the major either
-          docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
           docker tag prod ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_meta_tag.outputs.metatag }}
           fi
       - name: Push Docker Images
         run: |
-          docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
-          docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version}}
           docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.docker_version}}
-          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
+
+          # Only tag with `<major>` and `<major>.<minor>` if we are tagging `latest`
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" == "latest" ]]
           then
           docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}
+          docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version}}
+          fi
+
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
+          then
           docker push ${{ secrets.DOCKER_USER }}/one-app:${{ steps.set_docker_meta_tag.outputs.metatag }}
           fi
       - name: Trigger Development Image Publishing

--- a/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
+++ b/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
@@ -71,21 +71,33 @@ jobs:
         run: docker build -t dev . --target=development
       - name: Tag Docker Images
         run: |
-          docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version }}
+          # Always tag the exact version
           docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.docker_version }}
+
+          # Only tag with `<major>` and `<major>.<minor>` if we are tagging `latest`
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" == "latest" ]]
+          then
+          docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version }}
+          docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version }}
+          fi
+
+          # Finally tag with the requested meta tag
           if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
           then
-           # if we are not tagging `latest` or `next`, dont tag with the major either
-          docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version }}
           docker tag dev ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_meta_tag.outputs.metatag }}
           fi
       - name: Push Docker Images
         run: |
-          docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version }}
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.docker_version}}
-          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
+
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" == "latest" ]]
           then
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}
+          docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_version.outputs.major_version}}.${{ steps.set_docker_version.outputs.minor_version }}
+          fi
+
+          if [[ "${{ steps.set_docker_meta_tag.outputs.metatag }}" != "do_not_tag" ]]
+          then
           docker push ${{ secrets.DOCKER_USER }}/one-app-dev:${{ steps.set_docker_meta_tag.outputs.metatag }}
           fi
       - name: Publish One App Statics


### PR DESCRIPTION
When publishing a `next` version, do not tag as `major` or `major.minor` so that people who are targeting those don't get automatically move to pre-release

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.
