### PR TITLE
Feature/include websockets

### DIFF
--- a/__tests__/server/middleware/__snapshots__/csp.spec.js.snap
+++ b/__tests__/server/middleware/__snapshots__/csp.spec.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`csp middleware adds ip and localhost to csp in development 1`] = `"default-src 'none'; script-src 'nonce-00000000-0000-0000-0000-000000000000' 0.0.0.0:* localhost:* 'self'; connect-src 0.0.0.0:* localhost:* 'self';"`;
+exports[`csp middleware adds ip and localhost to csp in development 1`] = `"default-src 'none'; script-src 'nonce-00000000-0000-0000-0000-000000000000' 0.0.0.0:* localhost:* ws://localhost:* 'self'; connect-src 0.0.0.0:* localhost:* ws://localhost:* 'self';"`;
 
 exports[`csp updateCSP updates cspCache with given csp 1`] = `"default-src 'self';"`;

--- a/src/server/middleware/csp.js
+++ b/src/server/middleware/csp.js
@@ -61,7 +61,7 @@ const csp = () => (req, res, next) => {
   const scriptNonce = uuidV4();
   let updatedPolicy;
   if (process.env.NODE_ENV === 'development') {
-    const developmentAdditions = `${ip.address()}:* localhost:*`;
+    const developmentAdditions = `${ip.address()}:* localhost:* ws://localhost:*`;
     let updatedScriptSrc;
     if (process.env.ONE_CSP_ALLOW_INLINE_SCRIPTS === 'true') {
       updatedScriptSrc = insertSource(policy, 'script-src', developmentAdditions);


### PR DESCRIPTION
Made a fix for websockets blocked by csp

## Description
Added ws://localhost:* config in the csp file

## Motivation and Context
The bundler makes use of web sockets, these are currently blocked by the CSP.

## How Has This Been Tested?
Made sure that websocket is loaded 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
NA
