### PR TITLE
chore(holocron): take latest holocron for v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "cross-fetch": "^3.0.6",
         "express": "^4.17.1",
         "helmet": "^3.22.0",
-        "holocron": "^1.2.1",
+        "holocron": "^1.4.0",
         "holocron-module-route": "^1.2.1",
         "if-env": "^1.0.4",
         "immutable": "^4.0.0",
@@ -11847,9 +11847,9 @@
       }
     },
     "node_modules/holocron": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.2.1.tgz",
-      "integrity": "sha512-nLrdpQI4cLesgv2F7trg3KhrxYHZKg3hbxFq/l2eWzVj9kvaJm0WlLl5aAxd+SsESeodnt8hwOY+R2H889ridA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.4.0.tgz",
+      "integrity": "sha512-Wi1GxpMW6ThxWnozhGqb5TXJbtmcz4PUrXUaOPnKCwHnt4gQBT+ZFpzrj3LEpeupzv+Y1C6W7F48COnpD6ApoA==",
       "dependencies": {
         "@americanexpress/vitruvius": "^2.0.0",
         "hoist-non-react-statics": "^3.3.0",
@@ -32802,9 +32802,9 @@
       }
     },
     "holocron": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.2.1.tgz",
-      "integrity": "sha512-nLrdpQI4cLesgv2F7trg3KhrxYHZKg3hbxFq/l2eWzVj9kvaJm0WlLl5aAxd+SsESeodnt8hwOY+R2H889ridA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.4.0.tgz",
+      "integrity": "sha512-Wi1GxpMW6ThxWnozhGqb5TXJbtmcz4PUrXUaOPnKCwHnt4gQBT+ZFpzrj3LEpeupzv+Y1C6W7F48COnpD6ApoA==",
       "requires": {
         "@americanexpress/vitruvius": "^2.0.0",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "cross-fetch": "^3.0.6",
     "express": "^4.17.1",
     "helmet": "^3.22.0",
-    "holocron": "^1.2.1",
+    "holocron": "^1.4.0",
     "holocron-module-route": "^1.2.1",
     "if-env": "^1.0.4",
     "immutable": "^4.0.0",


### PR DESCRIPTION
## Motivation and Context
This brings a new opt-in performance enhancement of preventing the holocronModuleWrapper from calling 'toJS' on module state: https://github.com/americanexpress/holocron/blob/main/packages/holocron/docs/api/README.md#options-object

## How Has This Been Tested?
locally run against modules

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [x] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
N/A
