### PR TITLE
feat(createRequestHtmlFragment): allow modules to trigger a redirect from loadModuleData (v5)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,14 @@
         // console methods are how we log events
         "no-console": 0
       }
+    },
+    {
+      "files": [
+        "**/*.md"
+      ],
+      "rules": {
+        "no-console": 0
+      }
     }
   ]
 }

--- a/__tests__/server/config/env/runTime.spec.js
+++ b/__tests__/server/config/env/runTime.spec.js
@@ -281,6 +281,7 @@ describe('runTime', () => {
       expect(holocronModuleMapPath.defaultValue()).not.toBeDefined();
     });
 
+    // eslint-disable-next-line jest/expect-expect -- assertion is in nodeUrl
     it('ensures node can reach the URL', nodeUrl(holocronModuleMapPath));
 
     it('should use port numbers specified via HTTP_ONE_APP_DEV_CDN_PORT', () => {
@@ -299,6 +300,7 @@ describe('runTime', () => {
       expect(holocronServerMaxModulesRetry.defaultValue).toBe(undefined);
     });
 
+    // eslint-disable-next-line jest/expect-expect -- assertion is in positiveInteger
     it('validates the value as a positive integer', positiveInteger(holocronServerMaxModulesRetry));
   });
 
@@ -311,6 +313,7 @@ describe('runTime', () => {
       expect(holocronServerMaxSimModulesFetch.defaultValue).toBe(undefined);
     });
 
+    // eslint-disable-next-line jest/expect-expect -- assertion is in positiveInteger
     it(
       'validates the value as a positive integer',
       positiveInteger(holocronServerMaxSimModulesFetch)

--- a/__tests__/server/utils/createCircuitBreaker.spec.js
+++ b/__tests__/server/utils/createCircuitBreaker.spec.js
@@ -23,7 +23,7 @@ import createCircuitBreaker, {
 
 jest.useFakeTimers();
 
-const asyncFunctionThatMightFail = jest.fn(async () => false);
+const asyncFunctionThatMightFail = jest.fn(async () => ({ fallback: false }));
 const mockCircuitBreaker = createCircuitBreaker(asyncFunctionThatMightFail);
 
 jest.mock('holocron', () => ({
@@ -50,7 +50,7 @@ describe('Circuit breaker', () => {
     const input = 'hello, world';
     const value = await mockCircuitBreaker.fire(input);
     expect(asyncFunctionThatMightFail).toHaveBeenCalledWith(input);
-    expect(value).toBe(false);
+    expect(value).toEqual({ fallback: false });
   });
 
   it('should open the circuit when event loop delay threshold is exceeded', async () => {
@@ -62,7 +62,7 @@ describe('Circuit breaker', () => {
     jest.clearAllMocks();
     const value = await mockCircuitBreaker.fire('hola, mundo');
     expect(asyncFunctionThatMightFail).not.toHaveBeenCalled();
-    expect(value).toBe(true);
+    expect(value).toEqual({ fallback: true });
   });
 
   it('should not open the circuit when in development environment', async () => {
@@ -75,7 +75,7 @@ describe('Circuit breaker', () => {
     jest.clearAllMocks();
     const value = await mockCircuitBreaker.fire('hola, mundo');
     expect(asyncFunctionThatMightFail).toHaveBeenCalled();
-    expect(value).toBe(false);
+    expect(value).toEqual({ fallback: false });
   });
 
   it('should not open the circuit when threshold not exceeded', async () => {
@@ -87,7 +87,7 @@ describe('Circuit breaker', () => {
     jest.clearAllMocks();
     const value = await mockCircuitBreaker.fire('hola, mundo');
     expect(asyncFunctionThatMightFail).toHaveBeenCalled();
-    expect(value).toBe(false);
+    expect(value).toEqual({ fallback: false });
   });
 
   it('should not open the circuit when the root module is not loaded', async () => {
@@ -100,7 +100,7 @@ describe('Circuit breaker', () => {
     jest.clearAllMocks();
     const value = await mockCircuitBreaker.fire('hola, mundo');
     expect(asyncFunctionThatMightFail).toHaveBeenCalled();
-    expect(value).toBe(false);
+    expect(value).toEqual({ fallback: false });
   });
 
   it('should log when the healthcheck fails', async () => {

--- a/docs/api/modules/Loading-Data.md
+++ b/docs/api/modules/Loading-Data.md
@@ -29,6 +29,8 @@ Please see [`createSsrFetch`](./App-Configuration.md#createssrfetch) in the [App
 
 Please see the [Holocron Module Configuration](https://github.com/americanexpress/holocron/blob/main/packages/holocron/docs/api/README.md#holocron-module-configuration) from the Holocron API Docs for more information about other properties.
 
+Modules can trigger a server side redirect from `loadModuleData` by throwing an error that has the property `abortComposeModules` set to true and a `redirect` property containing an object with an HTTP status code (`status`) and the destination URL (`url`).
+
 ### `Module.holocron.loadModuleData`
 
 **Runs On**

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "cross-fetch": "^3.0.6",
         "express": "^4.17.1",
         "helmet": "^3.22.0",
-        "holocron": "^1.4.0",
+        "holocron": "^1.5.0",
         "holocron-module-route": "^1.2.1",
         "if-env": "^1.0.4",
         "immutable": "^4.0.0",
@@ -11847,9 +11847,9 @@
       }
     },
     "node_modules/holocron": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.4.0.tgz",
-      "integrity": "sha512-Wi1GxpMW6ThxWnozhGqb5TXJbtmcz4PUrXUaOPnKCwHnt4gQBT+ZFpzrj3LEpeupzv+Y1C6W7F48COnpD6ApoA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.5.0.tgz",
+      "integrity": "sha512-7wWb5uHzBR91OkOpn69WHiKvFBycQXoYpN4nTAYnBqCoJfi2+LF11AUVZ7lw6D91q+Q3SG+nRPI3SaCDtdftaQ==",
       "dependencies": {
         "@americanexpress/vitruvius": "^2.0.0",
         "hoist-non-react-statics": "^3.3.0",
@@ -32802,9 +32802,9 @@
       }
     },
     "holocron": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.4.0.tgz",
-      "integrity": "sha512-Wi1GxpMW6ThxWnozhGqb5TXJbtmcz4PUrXUaOPnKCwHnt4gQBT+ZFpzrj3LEpeupzv+Y1C6W7F48COnpD6ApoA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.5.0.tgz",
+      "integrity": "sha512-7wWb5uHzBR91OkOpn69WHiKvFBycQXoYpN4nTAYnBqCoJfi2+LF11AUVZ7lw6D91q+Q3SG+nRPI3SaCDtdftaQ==",
       "requires": {
         "@americanexpress/vitruvius": "^2.0.0",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "cross-fetch": "^3.0.6",
     "express": "^4.17.1",
     "helmet": "^3.22.0",
-    "holocron": "^1.4.0",
+    "holocron": "^1.5.0",
     "holocron-module-route": "^1.2.1",
     "if-env": "^1.0.4",
     "immutable": "^4.0.0",

--- a/src/server/utils/createCircuitBreaker.js
+++ b/src/server/utils/createCircuitBreaker.js
@@ -55,10 +55,10 @@ const checkMaxEventLoopDelay = async () => {
 };
 
 const createCircuitBreaker = (asyncFunctionThatMightFail) => {
-  // asyncFunctionThatMightFail should return false to indicate fallback is not needed
+  // asyncFunctionThatMightFail should return { fallback: false } to indicate fallback is not needed
   const breaker = new CircuitBreaker(asyncFunctionThatMightFail, options);
   // Fallback returns true to indicate fallback behavior is needed
-  breaker.fallback(() => true);
+  breaker.fallback(() => ({ fallback: true }));
   // Check the max event loop delay every 5 seconds
   breaker.healthCheck(checkMaxEventLoopDelay, 5e3);
   // Log when circuit breaker opens and closes


### PR DESCRIPTION
## Description

**This is a backport of #927 for one-app@5**

Depends on americanexpress/holocron#137.

With this change developers can throw an error from their `loadModuleData` function that will abort `composeModules` and trigger a redirect.

## Motivation and Context

This is a performance optimization for the redirect use case.

## How Has This Been Tested?

Unit tests

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [x] Dependency update
- [ ] Security update

## Checklist:

- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
