### PR TITLE
fix(load-modules): unnecessary calls to updateModuleRegistry (v5)

### DIFF
--- a/__tests__/integration/one-app.spec.js
+++ b/__tests__/integration/one-app.spec.js
@@ -64,6 +64,9 @@ describe('Tests that require Docker setup', () => {
     let browser;
     const moduleName = 'unhealthy-frank';
     const version = '0.0.0';
+    const revertErrorMatch = /There was an error loading module (?<moduleName>.*) at (?<url>.*). Ignoring (?<workingModule>.*) until .*/;
+    let requiredExternalsError;
+
     beforeAll(async () => {
       originalModuleMap = readModuleMap();
 
@@ -71,6 +74,7 @@ describe('Tests that require Docker setup', () => {
         moduleName,
         version,
       });
+      requiredExternalsError = searchForNextLogMatch(revertErrorMatch);
       ({ browser } = await setUpTestRunner({ oneAppLocalPortToUse, oneAppMetricsLocalPortToUse }));
     });
 
@@ -79,8 +83,6 @@ describe('Tests that require Docker setup', () => {
       writeModuleMap(originalModuleMap);
     });
     test('one-app starts up successfully with a bad module', async () => {
-      const revertErrorMatch = /There was an error loading module (?<moduleName>.*) at (?<url>.*). Ignoring (?<workingModule>.*) until .*/;
-      const requiredExternalsError = searchForNextLogMatch(revertErrorMatch);
       const loggedError = await requiredExternalsError;
       const [,
         problemModule,
@@ -315,13 +317,17 @@ describe('Tests that require Docker setup', () => {
       });
 
       describe('module removed from module map', () => {
-        afterAll(() => {
-          const integrityDigests = retrieveModuleIntegrityDigests({ moduleName: 'healthy-frank', version: sampleModuleVersion });
+        afterAll(async () => {
+          const integrityDigests = retrieveModuleIntegrityDigests({
+            moduleName: 'healthy-frank',
+            version: sampleModuleVersion,
+          });
           addModuleToModuleMap({
             moduleName: 'healthy-frank',
             version: sampleModuleVersion,
             integrityDigests,
           });
+          await waitFor(5000);
         });
 
         test('removes module from one-app', async () => {
@@ -343,7 +349,10 @@ describe('Tests that require Docker setup', () => {
       });
 
       describe('new module added to module map', () => {
-        afterAll(() => removeModuleFromModuleMap('late-frank'));
+        afterAll(async () => {
+          removeModuleFromModuleMap('late-frank');
+          await waitFor(5000);
+        });
 
         test('loads new module when module map updated', async () => {
           await browser.url(`${appAtTestUrls.browserUrl}/demo/late-frank`);
@@ -379,7 +388,7 @@ describe('Tests that require Docker setup', () => {
           let failedRootModuleConfigSearch;
           const failedRootModuleConfig = /Root module attempted to set the following non-overrideable options for the client but not the server:\\n\s{2}someApiUrl/;
 
-          beforeEach(async () => {
+          beforeAll(async () => {
             const nextVersion = '0.0.1';
             failedRootModuleConfigSearch = searchForNextLogMatch(failedRootModuleConfig);
             await addModuleToModuleMap({
@@ -390,8 +399,9 @@ describe('Tests that require Docker setup', () => {
             await waitFor(5000);
           });
 
-          afterEach(async () => {
+          afterAll(async () => {
             writeModuleMap(originalModuleMap);
+            await waitFor(5000);
           });
 
           test('writes an error to log when failed module config', async () => {
@@ -432,6 +442,7 @@ describe('Tests that require Docker setup', () => {
 
           afterEach(async () => {
             writeModuleMap(originalModuleMap);
+            await waitFor(5000);
           });
 
           test('writes an error to log when failed child module validation', async () => {
@@ -751,8 +762,9 @@ describe('Tests that require Docker setup', () => {
           const moduleName = 'cultured-frankie';
           const version = '0.0.1';
 
-          afterEach(() => {
+          afterEach(async () => {
             writeModuleMap(originalModuleMap);
+            await waitFor(5000);
           });
 
           test('fails to get external `react-intl` for child module as an unsupplied `requiredExternal` - logs failure', async () => {

--- a/__tests__/server/utils/__snapshots__/loadModules.spec.jsx.snap
+++ b/__tests__/server/utils/__snapshots__/loadModules.spec.jsx.snap
@@ -16,10 +16,10 @@ Object {
   "browser": Object {
     "modules": Object {
       "some-root": Object {
-        "baseUrl": "https://example.com/cdn/some-root/2.2.2/",
+        "baseUrl": "https://example.com/cdn/some-root/1.1.2/",
         "browser": Object {
           "integrity": "nggdfhr34",
-          "url": "https://example.com/cdn/some-root/2.2.2/some-root.browser.js",
+          "url": "https://example.com/cdn/some-root/1.1.2/some-root.browser.js",
         },
       },
     },
@@ -27,10 +27,10 @@ Object {
   "legacyBrowser": Object {
     "modules": Object {
       "some-root": Object {
-        "baseUrl": "https://example.com/cdn/some-root/2.2.2/",
+        "baseUrl": "https://example.com/cdn/some-root/1.1.2/",
         "legacyBrowser": Object {
           "integrity": "7567ee",
-          "url": "https://example.com/cdn/some-root/2.2.2/some-root.legacy.browser.js",
+          "url": "https://example.com/cdn/some-root/1.1.2/some-root.legacy.browser.js",
         },
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "lean-intl": "^4.2.2",
         "make-promises-safe": "^5.1.0",
         "matcher": "^3.0.0",
+        "object-hash": "^3.0.0",
         "opossum": "^6.2.1",
         "opossum-prometheus": "^0.3.0",
         "pidusage": "^3.0.0",
@@ -9483,6 +9484,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint-loader/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/eslint-loader/node_modules/p-locate": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -14911,6 +14920,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/lockfile-lint-api/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/lockfile-lint/node_modules/cosmiconfig": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
@@ -16380,9 +16398,9 @@
       }
     },
     "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "engines": {
         "node": ">= 6"
       }
@@ -31062,6 +31080,11 @@
             "semver": "^6.0.0"
           }
         },
+        "object-hash": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+          "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
+        },
         "p-locate": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
@@ -35179,6 +35202,14 @@
         "@yarnpkg/lockfile": "^1.1.0",
         "debug": "^4.1.1",
         "object-hash": "^2.0.1"
+      },
+      "dependencies": {
+        "object-hash": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+          "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+          "dev": true
+        }
       }
     },
     "lodash": {
@@ -36344,9 +36375,9 @@
       }
     },
     "object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-inspect": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "lean-intl": "^4.2.2",
     "make-promises-safe": "^5.1.0",
     "matcher": "^3.0.0",
+    "object-hash": "^3.0.0",
     "opossum": "^6.2.1",
     "opossum-prometheus": "^0.3.0",
     "pidusage": "^3.0.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This is a backport of https://github.com/americanexpress/one-app/pull/939 for One App v5

currently any module which does not get loaded correctly is re-required on every module map poll.
This change limits fetching and parsing modules to one round per change in the module map.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
limit unnecessary calls to require-from-string which consumes memory.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit and integration test.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
