### PR TITLE
fix(devCdn): requests were not using node-fetch API

### DIFF
--- a/__mocks__/node-fetch.js
+++ b/__mocks__/node-fetch.js
@@ -18,14 +18,23 @@ fetch.mockReturnJsonOnce = (obj) => {
     return fetch.mockImplementationOnce(() => Promise.reject(obj));
   }
 
-  return fetch.mockImplementationOnce(() => Promise.resolve({ body: JSON.stringify(obj) }));
+  return fetch.mockImplementationOnce(() => Promise.resolve({
+    json: () => Promise.resolve(obj),
+    text: () => Promise.resolve(JSON.stringify(obj)),
+    status: 200,
+  }));
 };
 
-fetch.mockReturnFileOnce = (body) => {
+fetch.mockReturnFileOnce = (body, status = 200) => {
   if (body instanceof Error) {
     return fetch.mockImplementationOnce(() => Promise.reject(body));
   }
 
-  return fetch.mockImplementationOnce(() => Promise.resolve({ body, statusCode: 200 }));
+  return fetch.mockImplementationOnce(
+    () => Promise.resolve({
+      text: () => Promise.resolve(body),
+      status,
+    })
+  );
 };
 module.exports = fetch;

--- a/__tests__/server/utils/devCdnFactory.spec.js
+++ b/__tests__/server/utils/devCdnFactory.spec.js
@@ -52,25 +52,7 @@ describe('one-app-dev-cdn', () => {
       },
     },
   };
-  const defaultRemoteMap = {
-    key: '234234',
-    modules: {
-      'module-b': {
-        node: {
-          url: 'https://example.com/cdn/module-b/1.0.0/module-b.node.js',
-          integrity: '123',
-        },
-        browser: {
-          url: 'https://example.com/cdn/module-b/1.0.0/module-b.browser.js',
-          integrity: '234',
-        },
-        legacyBrowser: {
-          url: 'https://example.com/cdn/module-b/1.0.0/module-b.legacy.browser.js',
-          integrity: '345',
-        },
-      },
-    },
-  };
+  let defaultRemoteMap;
 
   const defaultPublicDirContentsSetting = {
     moduleMapContent: JSON.stringify(defaultLocalMap),
@@ -92,6 +74,7 @@ describe('one-app-dev-cdn', () => {
     if (!allowCacheWrite) {
       mkdirp(pathToCache, { mode: 444 });
     }
+
     const modulesDir = path.join(mockLocalDevPublicPath, 'modules');
 
     mkdirp.sync(modulesDir);
@@ -138,7 +121,25 @@ describe('one-app-dev-cdn', () => {
     jest
       .resetAllMocks()
       .resetModules();
-
+    defaultRemoteMap = {
+      key: '234234',
+      modules: {
+        'module-b': {
+          node: {
+            url: 'https://example.com/cdn/module-b/1.0.0/module-b.node.js',
+            integrity: '123',
+          },
+          browser: {
+            url: 'https://example.com/cdn/module-b/1.0.0/module-b.browser.js',
+            integrity: '234',
+          },
+          legacyBrowser: {
+            url: 'https://example.com/cdn/module-b/1.0.0/module-b.legacy.browser.js',
+            integrity: '345',
+          },
+        },
+      },
+    };
     fetch.mockImplementation((url) => Promise.reject(new Error(`no mock for ${url} set up`)));
   });
 
@@ -629,7 +630,7 @@ describe('one-app-dev-cdn', () => {
       await fcdn.inject()
         .get('/module-map.json');
 
-      fetch.mockReturnFileOnce(gotError);
+      fetch.mockReturnFileOnce('body', 501);
       const moduleResponse = await fcdn.inject()
         .get('/cdn/module-b/1.0.0/some-langpack.json');
       expect(moduleResponse.statusCode).toBe(501);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

devCdn was using old `got` api instead of the newer `node-fetch` API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This broke local development when fetching a remote module map

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
