### PR TITLE
feat(holocron): allow mapStateToProps to be passed to holocron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "cross-fetch": "^3.0.6",
         "express": "^4.17.1",
         "helmet": "^3.22.0",
-        "holocron": "^1.5.0",
+        "holocron": "^1.6.0",
         "holocron-module-route": "^1.2.1",
         "if-env": "^1.0.4",
         "immutable": "^4.0.0",
@@ -11856,9 +11856,9 @@
       }
     },
     "node_modules/holocron": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.5.0.tgz",
-      "integrity": "sha512-7wWb5uHzBR91OkOpn69WHiKvFBycQXoYpN4nTAYnBqCoJfi2+LF11AUVZ7lw6D91q+Q3SG+nRPI3SaCDtdftaQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.6.0.tgz",
+      "integrity": "sha512-dZpmB8oPcd2cM3XtbFovZMfIJsVE9QVZOvf5/xQAjVhiU2DpI9qoqvhOJYBQPICkION1hlJRmENrHi6MUgUVKQ==",
       "dependencies": {
         "@americanexpress/vitruvius": "^2.0.0",
         "hoist-non-react-statics": "^3.3.0",
@@ -32825,9 +32825,9 @@
       }
     },
     "holocron": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.5.0.tgz",
-      "integrity": "sha512-7wWb5uHzBR91OkOpn69WHiKvFBycQXoYpN4nTAYnBqCoJfi2+LF11AUVZ7lw6D91q+Q3SG+nRPI3SaCDtdftaQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.6.0.tgz",
+      "integrity": "sha512-dZpmB8oPcd2cM3XtbFovZMfIJsVE9QVZOvf5/xQAjVhiU2DpI9qoqvhOJYBQPICkION1hlJRmENrHi6MUgUVKQ==",
       "requires": {
         "@americanexpress/vitruvius": "^2.0.0",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "cross-fetch": "^3.0.6",
     "express": "^4.17.1",
     "helmet": "^3.22.0",
-    "holocron": "^1.5.0",
+    "holocron": "^1.6.0",
     "holocron-module-route": "^1.2.1",
     "if-env": "^1.0.4",
     "immutable": "^4.0.0",


### PR DESCRIPTION
Bump holocron to 1.6.0.

This introduces a new API to holocron to allow you to pass mapStateToProps to holocron.