### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/api/modules/App-Configuration.md
+++ b/docs/api/modules/App-Configuration.md
@@ -499,7 +499,7 @@ if (!global.BROWSER) {
 }
 ```
 
-The `dnsCache` option allows for enabling applcation-level DNS caching. It is disabled by default. When enabled, the default max TTL is `Infinity`. 
+The `dnsCache` option allows for enabling application-level DNS caching. It is disabled by default. When enabled, the default max TTL is `Infinity`. 
 
 `maxTtl` affects the maximum lifetime of the entries received from the specified DNS server (TTL in seconds). If set to 0, it will make a new DNS query each time. It is not recommended to be lower than the DNS server response time in order to prevent bottlenecks.
 

--- a/docs/api/server/Environment-Variables.md
+++ b/docs/api/server/Environment-Variables.md
@@ -682,7 +682,7 @@ Must be one of: `no-referrer`, `no-referrer-when-downgrade`, `same-origin` or `s
 ```bash
 ONE_REFERRER_POLICY_OVERRIDE=String
 ```
-**Exampke**
+**Example**
 ```bash
 ONE_REFERRER_POLICY_OVERRIDE=no-referrer
 ```

--- a/docs/guides/Internationalizing-Your-Module.md
+++ b/docs/guides/Internationalizing-Your-Module.md
@@ -35,7 +35,7 @@ export default Child;
 
 ## Module Locale Files
 
-Next create the locale files. [one-app-locale-bundler](https://github.com/americanexpress/one-app-cli/tree/main/packages/one-app-locale-bundler) will bundle the locale files as a part of [one-app-bundler](https://github.com/americanexpress/one-app-cli/tree/main/packages/one-app-bundler). More information about locale folder stucture and naming can be found in the [README](https://github.com/americanexpress/one-app-cli/blob/main/packages/one-app-locale-bundler/README.md).
+Next create the locale files. [one-app-locale-bundler](https://github.com/americanexpress/one-app-cli/tree/main/packages/one-app-locale-bundler) will bundle the locale files as a part of [one-app-bundler](https://github.com/americanexpress/one-app-cli/tree/main/packages/one-app-bundler). More information about locale folder structure and naming can be found in the [README](https://github.com/americanexpress/one-app-cli/blob/main/packages/one-app-locale-bundler/README.md).
 
 Create a folder structure and content as follows (locale must follow BCP-47):
 ```
@@ -113,7 +113,7 @@ export default Parent;
 ```
 
 ## Access Locale and Language Pack
-Utilizing [mapStateToProps](https://react-redux.js.org/api/connect#mapstatetoprops-state-ownprops-object) will allow accessing the langugage pack and locale from the Redux state and provide them as props in the `Parent` component.
+Utilizing [mapStateToProps](https://react-redux.js.org/api/connect#mapstatetoprops-state-ownprops-object) will allow accessing the language pack and locale from the Redux state and provide them as props in the `Parent` component.
 
 Install React-Redux, Immutable, and PropTypes:
 ```

--- a/src/server/plugins/conditionallyAllowCors.js
+++ b/src/server/plugins/conditionallyAllowCors.js
@@ -30,7 +30,7 @@ export const setCorsOrigins = (newCorsOrigins = []) => {
 setCorsOrigins();
 
 /**
- * Sets configurable cors when 'renderPatialOnly' is enabled
+ * Sets configurable cors when 'renderPartialOnly' is enabled
  * @param {import('fastify').FastifyInstance} fastify app instance
  */
 const conditionallyAllowCors = async (fastify) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change corrects a few typos in documentation files

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed a typo and decided to correct 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Testing is not required for this type of change

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
