### PR TITLE
Update holocron - provide rejected modules

### DIFF
--- a/__tests__/server/utils/__snapshots__/pollModuleMap.spec.js.snap
+++ b/__tests__/server/utils/__snapshots__/pollModuleMap.spec.js.snap
@@ -29,18 +29,3 @@ exports[`pollModuleMap polling monitor logs when polling is not considered stopp
   "pollModuleMap: polling is working as expected. Last poll: 2000ms ago, Max poll: 10000ms.",
 ]
 `;
-
-exports[`pollModuleMap restores the state config on poll failure 1`] = `
-[
-  [
-    {
-      "client": {
-        "someUrl": "http://client.com",
-      },
-      "server": {
-        "someUrl": "http://server.com",
-      },
-    },
-  ],
-]
-`;

--- a/__tests__/server/utils/pollModuleMap.spec.js
+++ b/__tests__/server/utils/pollModuleMap.spec.js
@@ -19,21 +19,6 @@ jest.spyOn(global, 'setTimeout');
 jest.spyOn(global, 'setInterval');
 jest.spyOn(global, 'setImmediate');
 
-jest.mock('../../../src/server/utils/stateConfig', () => ({
-  setStateConfig: jest.fn(),
-  getClientStateConfig: jest.fn(),
-  getServerStateConfig: jest.fn(),
-  backupModuleStateConfig: jest.fn(() => ({
-    client: {
-      someUrl: 'http://client.com',
-    },
-    server: {
-      someUrl: 'http://server.com',
-    },
-  })),
-  restoreModuleStateConfig: jest.fn(),
-}));
-
 describe('pollModuleMap', () => {
   jest.spyOn(console, 'log').mockImplementation(() => {});
   jest.spyOn(console, 'warn').mockImplementation(() => {});
@@ -45,10 +30,6 @@ describe('pollModuleMap', () => {
   let setGauge;
   let resetGauge;
   let holocronMetrics;
-  let getModulesUsingExternals;
-  let setModulesUsingExternals;
-  let restoreModuleStateConfig;
-  let backupModuleStateConfig;
 
   function load({ min, max } = {}) {
     jest.resetModules();
@@ -65,7 +46,7 @@ describe('pollModuleMap', () => {
       process.env.ONE_MAP_POLLING_MAX = `${max}`;
     }
 
-    loadModulesPromise = Promise.resolve({});
+    loadModulesPromise = Promise.resolve({ loadModules: {}, rejectedModules: {} });
     jest.mock('../../../src/server/utils/loadModules', () => jest.fn());
     loadModules = require('../../../src/server/utils/loadModules');
     loadModules.mockImplementation(() => loadModulesPromise);
@@ -78,9 +59,6 @@ describe('pollModuleMap', () => {
       resetGauge,
       holocron: holocronMetrics,
     } = require('../../../src/server/metrics'));
-
-    ({ getModulesUsingExternals, setModulesUsingExternals } = require('../../../src/server/utils/onModuleLoad'));
-    ({ restoreModuleStateConfig, backupModuleStateConfig } = require('../../../src/server/utils/stateConfig'));
 
     return require('../../../src/server/utils/pollModuleMap');
   }
@@ -127,77 +105,22 @@ describe('pollModuleMap', () => {
     );
   });
 
-  it('calls loadModules', () => {
+  it('calls loadModules', async () => {
     const { default: pollModuleMap } = load();
-    pollModuleMap();
+    await pollModuleMap();
 
     expect(console.log).toHaveBeenCalledWith('pollModuleMap: polling...');
     expect(loadModules).toHaveBeenCalledTimes(1);
     expect(incrementCounter).toHaveBeenCalledTimes(1);
     expect(incrementCounter).toHaveBeenCalledWith(holocronMetrics.moduleMapPoll);
-    return loadModulesPromise;
   });
 
   it('schedules a new polling', async () => {
     const { default: pollModuleMap } = load();
     await pollModuleMap();
     expect(loadModules).toHaveBeenCalledTimes(1);
-    return loadModulesPromise
-      .then(() => {
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(setTimeout.mock.calls[0][0]).toBe(pollModuleMap);
-      });
-  });
-
-  it('does not reset the modules using externals on poll success', () => {
-    const { default: pollModuleMap } = load();
-    pollModuleMap();
-
-    return loadModulesPromise
-      .then(() => {
-        expect(getModulesUsingExternals).toHaveBeenCalledTimes(1);
-        expect(setModulesUsingExternals).not.toHaveBeenCalled();
-      });
-  });
-
-  it('resets the modules using externals on poll failure', async () => {
-    const { default: pollModuleMap } = load();
-
-    console.log
-      // monitor setup
-      .mockImplementationOnce(() => { /* noop a few times */ })
-      // pollModuleMap run 1
-      .mockImplementationOnce(() => { throw new Error('STDOUT pipe closed unexpectedly'); });
-
-    await pollModuleMap();
-
-    expect(getModulesUsingExternals).toHaveBeenCalledTimes(1);
-    expect(setModulesUsingExternals).toHaveBeenCalledTimes(1);
-    expect(setModulesUsingExternals).toHaveBeenCalledWith(['module-a', 'module-b']);
-  });
-
-  it('restores the state config on poll failure', async () => {
-    const { default: pollModuleMap } = load();
-
-    console.log
-      // monitor setup
-      .mockImplementationOnce(() => { /* noop a few times */ })
-      // pollModuleMap run 1
-      .mockImplementationOnce(() => { throw new Error('STDOUT pipe closed unexpectedly'); });
-
-    await pollModuleMap();
-    expect(backupModuleStateConfig).toHaveBeenCalled();
-    expect(restoreModuleStateConfig.mock.calls).toMatchSnapshot();
-  });
-
-  it('does not reset the modules when error was thrown getting modules using externals', async () => {
-    const { default: pollModuleMap } = load();
-
-    getModulesUsingExternals.mockImplementationOnce(() => { throw new Error('failed to get modules using externals'); });
-
-    await pollModuleMap();
-    expect(getModulesUsingExternals).toHaveBeenCalledTimes(1);
-    expect(setModulesUsingExternals).not.toHaveBeenCalled();
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout.mock.calls[0][0]).toBe(pollModuleMap);
   });
 
   it('schedules a new polling despite console.log throwing on the initial check', async () => {
@@ -289,35 +212,28 @@ describe('pollModuleMap', () => {
     setTimeout.mockImplementationOnce(() => ({ unref: mockUnref }));
     await pollModuleMap();
     expect(loadModules).toHaveBeenCalledTimes(1);
-
-    return loadModulesPromise
-      .then(() => {
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(mockUnref).toHaveBeenCalledTimes(1);
-      });
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(mockUnref).toHaveBeenCalledTimes(1);
   });
 
   it('resets the time to the next polling to the minimum if there were updates', async () => {
     const { default: pollModuleMap } = load();
-    const moduleMapUpdates = { 'module-name': '1.2.3' };
-    loadModulesPromise = Promise.resolve(moduleMapUpdates);
+    const moduleMapUpdates = { 'module-name': 'module-data-here' };
+    loadModulesPromise = Promise.resolve({ loadedModules: moduleMapUpdates });
     await pollModuleMap();
+
     expect(loadModules).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledTimes(3);
+    expect(console.log.mock.calls[2][0]).toMatch(/^pollModuleMap: 1 modules loaded\/updated:$/);
+    expect(console.log.mock.calls[2][1]).toEqual(moduleMapUpdates);
 
-    return loadModulesPromise
-      .then(() => {
-        expect(console.log).toHaveBeenCalledTimes(3);
-        expect(console.log.mock.calls[2][0]).toMatch(/^pollModuleMap: 1 modules loaded\/updated:$/);
-        expect(console.log.mock.calls[2][1]).toEqual(moduleMapUpdates);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, 5e3);
 
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, 5e3);
-
-        expect(setGauge).toHaveBeenCalledTimes(1);
-        expect(setGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollWait, 5);
-        expect(resetGauge).toHaveBeenCalledTimes(1);
-        expect(resetGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollConsecutiveErrors);
-      });
+    expect(setGauge).toHaveBeenCalledTimes(1);
+    expect(setGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollWait, 5);
+    expect(resetGauge).toHaveBeenCalledTimes(1);
+    expect(resetGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollConsecutiveErrors);
   });
 
   it('increases the time to the next polling if there were no updates', async () => {
@@ -325,23 +241,20 @@ describe('pollModuleMap', () => {
     await pollModuleMap();
     expect(loadModules).toHaveBeenCalledTimes(1);
 
-    return loadModulesPromise
-      .then(() => {
-        expect(console.log).toHaveBeenCalledTimes(3);
-        expect(console.log.mock.calls[2][0]).toMatch(
-          /^pollModuleMap: no updates, looking again in \d+s$/
-        );
+    expect(console.log).toHaveBeenCalledTimes(3);
+    expect(console.log.mock.calls[2][0]).toMatch(
+      /^pollModuleMap: no updates, looking again in \d+s$/
+    );
 
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(setTimeout.mock.calls[0][0]).toBe(pollModuleMap);
-        expect(setTimeout.mock.calls[0][1]).toBeGreaterThanOrEqual(5e3 * 1.25);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout.mock.calls[0][0]).toBe(pollModuleMap);
+    expect(setTimeout.mock.calls[0][1]).toBeGreaterThanOrEqual(5e3 * 1.25);
 
-        expect(setGauge).toHaveBeenCalledTimes(1);
-        expect(setGauge.mock.calls[0][0]).toBe(holocronMetrics.moduleMapPollWait);
-        expect(setGauge.mock.calls[0][1]).toBeGreaterThanOrEqual(5 * 1.25);
-        // ensure we're using seconds, not milliseconds
-        expect(setGauge.mock.calls[0][1]).toBeLessThan(8 * 1.25);
-      });
+    expect(setGauge).toHaveBeenCalledTimes(1);
+    expect(setGauge.mock.calls[0][0]).toBe(holocronMetrics.moduleMapPollWait);
+    expect(setGauge.mock.calls[0][1]).toBeGreaterThanOrEqual(5 * 1.25);
+    // ensure we're using seconds, not milliseconds
+    expect(setGauge.mock.calls[0][1]).toBeLessThan(8 * 1.25);
   });
 
   it('resets the time to the next polling to the minimum if there were errors', async () => {
@@ -350,22 +263,34 @@ describe('pollModuleMap', () => {
     loadModulesPromise = Promise.reject(error);
     await pollModuleMap();
     expect(loadModules).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('pollModuleMap: error polling', error);
 
-    return loadModulesPromise
-      // catch and then so as to run after pollModuleMap's error handling
-      .catch((err) => err)
-      .then(() => {
-        expect(console.error).toHaveBeenCalledTimes(1);
-        expect(console.error).toHaveBeenCalledWith('pollModuleMap: error polling', error);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, 5e3);
 
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, 5e3);
+    expect(setGauge).toHaveBeenCalledTimes(1);
+    expect(setGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollWait, 5);
+    expect(incrementGauge).toHaveBeenCalledTimes(1);
+    expect(incrementGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollConsecutiveErrors);
+  });
 
-        expect(setGauge).toHaveBeenCalledTimes(1);
-        expect(setGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollWait, 5);
-        expect(incrementGauge).toHaveBeenCalledTimes(1);
-        expect(incrementGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollConsecutiveErrors);
-      });
+  it('resets the time to the next polling to the minimum if there were rejected modules', async () => {
+    const { default: pollModuleMap } = load();
+    loadModulesPromise = Promise.resolve({ rejectedModules: { 'bad-module': { reasonForRejection: 'not compatible' } } });
+    await pollModuleMap();
+    expect(loadModules).toHaveBeenCalledTimes(1);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith('pollModuleMap: 1 modules rejected:', ['bad-module: not compatible']);
+
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, 5e3);
+
+    expect(setGauge).toHaveBeenCalledTimes(1);
+    expect(setGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollWait, 5);
+    expect(incrementGauge).toHaveBeenCalledTimes(1);
+    expect(incrementGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollConsecutiveErrors);
   });
 
   it('schedules a new polling despite console.error throwing on the initial check', async () => {
@@ -426,11 +351,7 @@ describe('pollModuleMap', () => {
     const { default: pollModuleMap, getModuleMapHealth } = load();
     await pollModuleMap();
     expect(loadModules).toHaveBeenCalledTimes(1);
-
-    return loadModulesPromise
-      .then(() => {
-        expect(getModuleMapHealth()).toBe(true);
-      });
+    expect(getModuleMapHealth()).toBe(true);
   });
 
   it('marks the module map as unhealthy if there is an error', async () => {
@@ -440,12 +361,7 @@ describe('pollModuleMap', () => {
     loadModulesPromise = Promise.reject(error);
     await pollModuleMap();
     expect(loadModules).toHaveBeenCalledTimes(1);
-    return loadModulesPromise
-      // catch and then so as to run after pollModuleMap's error handling
-      .catch((err) => err)
-      .then(() => {
-        expect(getModuleMapHealth()).toBe(false);
-      });
+    expect(getModuleMapHealth()).toBe(false);
   });
 
   describe('polling monitor', () => {

--- a/__tests__/server/utils/pollModuleMap.spec.js
+++ b/__tests__/server/utils/pollModuleMap.spec.js
@@ -217,7 +217,7 @@ describe('pollModuleMap', () => {
   });
 
   it('resets the time to the next polling to the minimum if there were updates', async () => {
-    const { default: pollModuleMap } = load();
+    const { default: pollModuleMap, MIN_POLL_TIME } = load();
     const moduleMapUpdates = { 'module-name': 'module-data-here' };
     loadModulesPromise = Promise.resolve({ loadedModules: moduleMapUpdates });
     await pollModuleMap();
@@ -228,7 +228,7 @@ describe('pollModuleMap', () => {
     expect(console.log.mock.calls[2][1]).toEqual(moduleMapUpdates);
 
     expect(setTimeout).toHaveBeenCalledTimes(1);
-    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, 5e3);
+    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, MIN_POLL_TIME);
 
     expect(setGauge).toHaveBeenCalledTimes(1);
     expect(setGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollWait, 5);
@@ -237,7 +237,7 @@ describe('pollModuleMap', () => {
   });
 
   it('increases the time to the next polling if there were no updates', async () => {
-    const { default: pollModuleMap } = load();
+    const { default: pollModuleMap, MIN_POLL_TIME } = load();
     await pollModuleMap();
     expect(loadModules).toHaveBeenCalledTimes(1);
 
@@ -248,7 +248,8 @@ describe('pollModuleMap', () => {
 
     expect(setTimeout).toHaveBeenCalledTimes(1);
     expect(setTimeout.mock.calls[0][0]).toBe(pollModuleMap);
-    expect(setTimeout.mock.calls[0][1]).toBeGreaterThanOrEqual(5e3 * 1.25);
+    // check that the interval has increased
+    expect(setTimeout.mock.calls[0][1]).toBeGreaterThanOrEqual(MIN_POLL_TIME * 1.25);
 
     expect(setGauge).toHaveBeenCalledTimes(1);
     expect(setGauge.mock.calls[0][0]).toBe(holocronMetrics.moduleMapPollWait);
@@ -258,7 +259,7 @@ describe('pollModuleMap', () => {
   });
 
   it('resets the time to the next polling to the minimum if there were errors', async () => {
-    const { default: pollModuleMap } = load();
+    const { default: pollModuleMap, MIN_POLL_TIME } = load();
     const error = { message: 'sample test error' };
     loadModulesPromise = Promise.reject(error);
     await pollModuleMap();
@@ -267,7 +268,8 @@ describe('pollModuleMap', () => {
     expect(console.error).toHaveBeenCalledWith('pollModuleMap: error polling', error);
 
     expect(setTimeout).toHaveBeenCalledTimes(1);
-    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, 5e3);
+    // check that the interval has reset
+    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, MIN_POLL_TIME);
 
     expect(setGauge).toHaveBeenCalledTimes(1);
     expect(setGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollWait, 5);
@@ -276,7 +278,7 @@ describe('pollModuleMap', () => {
   });
 
   it('resets the time to the next polling to the minimum if there were rejected modules', async () => {
-    const { default: pollModuleMap } = load();
+    const { default: pollModuleMap, MIN_POLL_TIME } = load();
     loadModulesPromise = Promise.resolve({ rejectedModules: { 'bad-module': { reasonForRejection: 'not compatible' } } });
     await pollModuleMap();
     expect(loadModules).toHaveBeenCalledTimes(1);
@@ -285,7 +287,8 @@ describe('pollModuleMap', () => {
     expect(console.warn).toHaveBeenCalledWith('pollModuleMap: 1 modules rejected:', ['bad-module: not compatible']);
 
     expect(setTimeout).toHaveBeenCalledTimes(1);
-    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, 5e3);
+    // check that the poll interval is reset to min.
+    expect(setTimeout).toHaveBeenCalledWith(pollModuleMap, MIN_POLL_TIME);
 
     expect(setGauge).toHaveBeenCalledTimes(1);
     expect(setGauge).toHaveBeenCalledWith(holocronMetrics.moduleMapPollWait, 5);

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "fastify": "^4.10.2",
         "fastify-plugin": "^4.2.0",
         "helmet": "^6.0.0",
-        "holocron": "^1.6.0",
+        "holocron": "^1.7.0",
         "holocron-module-route": "^1.3.0",
         "if-env": "^1.0.4",
         "immutable": "^4.1.0",
@@ -14651,9 +14651,9 @@
       }
     },
     "node_modules/holocron": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.6.0.tgz",
-      "integrity": "sha512-dZpmB8oPcd2cM3XtbFovZMfIJsVE9QVZOvf5/xQAjVhiU2DpI9qoqvhOJYBQPICkION1hlJRmENrHi6MUgUVKQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/holocron/-/holocron-1.7.0.tgz",
+      "integrity": "sha512-gz88zT+JuIWC19o+7tgFl9whUqrCS5TGFga2QSJU3CLLYzlYMf1UsW13lGE1QjBIQDDwYlwPY2+FSUeejeg9mg==",
       "dependencies": {
         "@americanexpress/vitruvius": "^2.0.0",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "fastify": "^4.10.2",
     "fastify-plugin": "^4.2.0",
     "helmet": "^6.0.0",
-    "holocron": "^1.6.0",
+    "holocron": "^1.7.0",
     "holocron-module-route": "^1.3.0",
     "if-env": "^1.0.4",
     "immutable": "^4.1.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Consuming the latest Holocron version which includes rejected module updates.
Makes use of rejected modules to provide additional logs and reset the module map poll time.

Additional PR should follow which adds the rejected module information in the metrics.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After Holocron resiliency update one-app no longer reset when a module is rejected. The error is also logged only once which reduces the visibility of the error.  
The aim of this is to improve DX when modules rejected. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally and test suite.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
