### PR TITLE
fix(server): remove extra nodeFramework key from log entries

### DIFF
--- a/__tests__/server/utils/logging/__snapshots__/production-formatter.spec.js.snap
+++ b/__tests__/server/utils/logging/__snapshots__/production-formatter.spec.js.snap
@@ -12,7 +12,6 @@ exports[`production-formatter encodes as parseable JSON 1`] = `
   },
   "level": "error",
   "message": "1 2 3",
-  "nodeFramework": "fastify",
   "schemaVersion": "0.3.0",
   "timestamp": "2018-03-02T02:39:32.948Z",
 }
@@ -36,7 +35,6 @@ exports[`production-formatter errors encodes ClientReportedError Error as parsea
 ",
   },
   "level": "error",
-  "nodeFramework": "fastify",
   "request": {
     "address": {
       "uri": "https://example.com/page-the/error/occurred-on",
@@ -84,7 +82,6 @@ exports[`production-formatter errors encodes Server Reported Error as parseable 
       },
     },
   },
-  "nodeFramework": "fastify",
   "schemaVersion": "0.3.0",
   "timestamp": "2018-03-02T02:39:32.948Z",
 }
@@ -115,7 +112,6 @@ exports[`production-formatter errors encodes as parseable JSON 1`] = `
   },
   "level": "error",
   "message": "unable to do the thing",
-  "nodeFramework": "fastify",
   "schemaVersion": "0.3.0",
   "timestamp": "2018-03-02T02:39:32.948Z",
 }
@@ -208,7 +204,6 @@ exports[`production-formatter types encodes request as parseable JSON 1`] = `
     "id": "host-123:1234",
   },
   "level": "error",
-  "nodeFramework": "fastify",
   "request": {
     "address": {
       "url": "https://example.org/server",
@@ -246,7 +241,6 @@ exports[`production-formatter types uses the default util.format when given an u
   },
   "level": "error",
   "message": "{ type: 'yolo' }",
-  "nodeFramework": "fastify",
   "schemaVersion": "0.3.0",
   "timestamp": "2018-03-02T02:39:32.948Z",
 }

--- a/src/server/utils/logging/production-formatter.js
+++ b/src/server/utils/logging/production-formatter.js
@@ -66,7 +66,6 @@ function getBaseEntry(level) {
     device,
     level: nodeLevelToSchemaLevel[level],
     timestamp: new Date().toISOString(),
-    nodeFramework: 'fastify',
   };
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the `"nodeFramework":"fastify"` key & value in log entries.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Libraries and implementation can be tracked by the application version. Rather than an extra key in each log entry the `package-lock.json` for the tagged version, or the `node_modules` in the published image/running container can be inspected.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Existing tests, updated the snapshots.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
I believe very little, if any. Perhaps slightly less storage space required, though not a high concern given the verbosity of the entries.