### PR TITLE
fix(memoryLeak): disable cache for transitjs

### DIFF
--- a/src/universal/utils/transit.js
+++ b/src/universal/utils/transit.js
@@ -64,13 +64,14 @@ const modifiedHandlers = handlers.withExtraHandlers(extraHandlers);
 const reader = transit.reader('json', {
   handlers: modifiedHandlers.read,
   cache: false,
-  // Copied from transit-immutable-js. Without this, Error fails to read.
+  // Taken from transit-immutable-js. Without this, Error fails to read.
+  // https://github.com/glenjamin/transit-immutable-js/blob/cb0ac0799d730080ea2403dba4061cf9c9d7b9bd/index.js#L6
   mapBuilder: {
     init() {
       return {};
     },
     add(m, k, v) {
-      // eslint-disable-next-line no-param-reassign
+      // eslint-disable-next-line no-param-reassign -- Keeping what is done by transit-immutable-js
       m[k] = v;
       return m;
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We noticed a memory leak happening where if non-immutable data was put into the store, transit-js would cache all the keys for that non-immutable data. This cache persisted across calls, and would grow indefinitely. 

The solution is to use transit-js directly, and disable the cache. unfortunately transit-immutable-js does not allow you to pass options to transit-js, so we have to add handles manually.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

memory leaks are bad

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested independently and unit tested

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
