### PR TITLE
feat(server): add SSR React rendering summary metric

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "editorconfig": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/__tests__/integration/__snapshots__/one-app.spec.js.snap
+++ b/__tests__/integration/__snapshots__/one-app.spec.js.snap
@@ -72,6 +72,7 @@ Array [
   "oneapp_holocron_module_map_poll_wait_seconds",
   "oneapp_holocron_module_map_updated_total",
   "oneapp_intl_cache_size_total",
+  "oneapp_ssr_react_rendering_seconds",
   "oneapp_version_info",
   "process_cpu_seconds_total",
   "process_cpu_system_seconds_total",

--- a/__tests__/server/metrics/summaries.spec.js
+++ b/__tests__/server/metrics/summaries.spec.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+describe('summaries', () => {
+  let Summary;
+
+  function load() {
+    jest.resetModules();
+
+    jest.mock('prom-client');
+    ({ Summary } = require('prom-client'));
+
+    return require('../../../src/server/metrics/summaries');
+  }
+
+  describe('createSummary', () => {
+    it('is a function', () => {
+      const { createSummary } = load();
+      expect(createSummary).toBeInstanceOf(Function);
+    });
+
+    it('creates a summary with the options', () => {
+      const { createSummary } = load();
+      createSummary({ name: 'yup' });
+      expect(Summary).toHaveBeenCalledTimes(1);
+      const summary = Summary.mock.instances[0];
+      expect(summary).toBeInstanceOf(Summary);
+    });
+
+    it('does not create a new summary if one with the same name already exists', () => {
+      const { createSummary } = load();
+      createSummary({ name: 'yup' });
+      expect(Summary).toHaveBeenCalledTimes(1);
+      createSummary({ name: 'yup' });
+      expect(Summary).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('startSummaryTimer', () => {
+    it('is a function', () => {
+      const { startSummaryTimer } = load();
+      expect(startSummaryTimer).toBeInstanceOf(Function);
+    });
+
+    it('throws an error if the summary does not exist', () => {
+      const { startSummaryTimer } = load();
+      expect(() => startSummaryTimer('nope')).toThrowErrorMatchingInlineSnapshot(
+        '"unable to find summary nope, please create it first"'
+      );
+    });
+
+    it('calls the startTimer method of the summary', () => {
+      const { createSummary, startSummaryTimer } = load();
+      createSummary({ name: 'yup' });
+      const summary = Summary.mock.instances[0];
+      startSummaryTimer('yup');
+      expect(summary.startTimer).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls the startTimer method of the summary with the arguments', () => {
+      const { createSummary, startSummaryTimer } = load();
+      createSummary({ name: 'yup' });
+      const summary = Summary.mock.instances[0];
+      startSummaryTimer('yup', 1, 'two', [null, null, null]);
+      expect(summary.startTimer).toHaveBeenCalledTimes(1);
+      expect(summary.startTimer).toHaveBeenCalledWith(1, 'two', [null, null, null]);
+    });
+  });
+});

--- a/src/server/metrics/ssr.js
+++ b/src/server/metrics/ssr.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import { createSummary } from './summaries';
+
+import createMetricNamespace from './create-metric-namespace';
+
+const ssrNamespace = createMetricNamespace('ssr');
+
+createSummary({
+  name: ssrNamespace('react_rendering', 'seconds'),
+  help: 'time taken by React to render HTML',
+  labelNames: ['renderMethodName'],
+});
+
+export default ssrNamespace.getMetricNames();

--- a/src/server/metrics/summaries.js
+++ b/src/server/metrics/summaries.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 American Express Travel Related Services Company, Inc.
+ * Copyright 2023 American Express Travel Related Services Company, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,30 +14,26 @@
  * permissions and limitations under the License.
  */
 
-import { incrementCounter } from './counters';
-import { incrementGauge, setGauge, resetGauge } from './gauges';
-import { startSummaryTimer } from './summaries';
+import { Summary } from 'prom-client';
 
-import holocron from './holocron';
-import intlCache from './intl-cache';
-import * as appVersion from './app-version';
-import ssr from './ssr';
+const summaries = {};
+
+function createSummary(opts) {
+  const { name } = opts;
+  if (summaries[name]) {
+    return;
+  }
+  summaries[name] = new Summary(opts);
+}
+
+function startSummaryTimer(name, ...args) {
+  if (!summaries[name]) {
+    throw new Error(`unable to find summary ${name}, please create it first`);
+  }
+  return summaries[name].startTimer(...args);
+}
 
 export {
-  // counters
-  incrementCounter,
-
-  // gauges
-  incrementGauge,
-  setGauge,
-  resetGauge,
-
-  // summaries
+  createSummary,
   startSummaryTimer,
-
-  // metrics
-  holocron,
-  appVersion,
-  intlCache,
-  ssr,
 };


### PR DESCRIPTION
## Description
Add a `oneapp_ssr_react_rendering_seconds` summary metric split by `renderMethodName` label.

Mirror of #991 for 5.x

## Motivation and Context
Server-Side Rendering (SSR) can be resource intensive. It is useful to operators to know a bit more about the time taken to render the HTML via React.

## How Has This Been Tested?
Run locally, comparing manual timers (`process.hrtime.bigint`) to the values visible in `http://localhost:3005/metrics`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
DevOps has more telemetry to track server utilization to aid SSR efficiency in modules and possible server scaling.