### PR TITLE
chore(workflows): remove Node.js 12.x & 14.x from on-pr-and-trunk_one-app-unit-and-lint-tests

### DIFF
--- a/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
+++ b/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
+++ b/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description
Remove Node.js 12.x and 14.x from the PR testing matrix; 16.x remains.

## Motivation and Context
12.x and 14.x are EOL

## How Has This Been Tested?
PR checks

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
Developers may need to change the version of Node.js they have installed to run this directly on their machines. However, they should  have done this already to minimize the delta between their machines and the image artifact.