### PR TITLE
docs(post-to-modules): correct request body info

### DIFF
--- a/docs/guides/Post-To-Modules.md
+++ b/docs/guides/Post-To-Modules.md
@@ -5,7 +5,7 @@
 # POST To Module Routes
 
 To enable post set [`ONE_ENABLE_POST_TO_MODULE_ROUTES`](../api/server/Environment-Variables.md#ONE_ENABLE_POST_TO_MODULE_ROUTES) environment variable.
-Request body must be either a JSON object or FormData of less than 15KB in size and is passed as props to your module.
+Request body must be either a JSON object or FormData of less than 15KB in size and will be passed via the request object to the `buildInitialState` method.
 
 Supported media types:
 - `application/json`


### PR DESCRIPTION
## Description
Fixes #902 

## Motivation and Context
AFAICT There's no special handling for the request body like passing it as props to your module.  It's just parsed by https://github.com/fastify/fastify-formbody and present on the request object and can be handled with `buildInitialState`.

## How Has This Been Tested?
Doc update.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
Corrects wrong documentation.