### PR TITLE
test(lint): disable expected warnings

### DIFF
--- a/docs/guides/Partial-Rendering.md
+++ b/docs/guides/Partial-Rendering.md
@@ -299,7 +299,7 @@ export default function EmailPartialsChildModule() {
 
   return (
     <dangerously-return-only-doctype
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: html }} // eslint-disable-line react/no-danger
     />
   );
 }

--- a/prod-sample/sample-modules/.eslintrc.json
+++ b/prod-sample/sample-modules/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "extends": "amex",
   "rules": {
-    "import/no-unresolved": "warn",
-    "react/no-unknown-property": "warn"
+    "import/no-unresolved": "off",
+    "react/no-unknown-property": "off",
+    "you-dont-need-lodash-underscore/get": "off"
   }
 }


### PR DESCRIPTION
# Description
Fixes #1000 

## Motivation and Context
These lint failures will not be fixed so the warnings are just noise and mask any actual warnings that come up during development.
* `import/no-unresolved` and `react/no-unknown-property` are false positives due to how the sample modules are packaged.
* `you-dont-need-lodash-underscore/get` does not really provide any value on the sample modules unless there is a desire to rewrite it to not use lodash.
* `dangerouslySetInnerHTML` is used intentionally.

## How Has This Been Tested?
No code changes involved.  `npm run test:lint` has been run and produced no output.

```
> @americanexpress/one-app@6.4.0 test:lint
> eslint --ext js,jsx,md,snap .


> @americanexpress/one-app@6.4.0 test:unit
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
No impact to users.  Improvement for One App developers.