### PR TITLE
fix(configureRequestLog): use default when configured with undefined

### DIFF
--- a/__tests__/server/utils/logging/fastifyPlugin.spec.js
+++ b/__tests__/server/utils/logging/fastifyPlugin.spec.js
@@ -729,4 +729,68 @@ describe('fastifyPlugin', () => {
       });
     });
   });
+
+  describe('setConfigureRequestLog', () => {
+    it('resets to default', async () => {
+      const request = {
+        headers: {},
+      };
+      const reply = {
+        getHeader: jest.fn(),
+        raw: {},
+      };
+
+      const fastify = {
+        decorateRequest: jest.fn((name, fn) => {
+          fastify[name] = fn;
+        }),
+        addHook: jest.fn((name, fn) => {
+          if (!fastify[name]) {
+            fastify[name] = fn;
+          }
+        }),
+      };
+
+      fastifyPlugin(fastify, null, jest.fn());
+      setConfigureRequestLog(() => {
+        throw new Error('shh');
+      });
+      setConfigureRequestLog();
+
+      await fastify.onResponse(request, reply);
+
+      expect(logger.info.mock.calls[0][0]).toMatchInlineSnapshot(`
+        {
+          "request": {
+            "address": {
+              "uri": "",
+            },
+            "direction": "in",
+            "metaData": {
+              "correlationId": undefined,
+              "forwarded": null,
+              "forwardedFor": null,
+              "host": null,
+              "locale": undefined,
+              "location": undefined,
+              "method": undefined,
+              "referrer": null,
+              "userAgent": null,
+            },
+            "protocol": undefined,
+            "statusCode": undefined,
+            "statusText": undefined,
+            "timings": {
+              "duration": 0,
+              "requestOverhead": NaN,
+              "responseBuilder": 0,
+              "routeHandler": NaN,
+              "ttfb": 0,
+            },
+          },
+          "type": "request",
+        }
+      `);
+    });
+  });
 });

--- a/src/server/utils/logging/fastifyPlugin.js
+++ b/src/server/utils/logging/fastifyPlugin.js
@@ -201,12 +201,17 @@ const fastifyPlugin = (fastify, _opts, done) => {
   });
 
   fastify.addHook('onResponse', async (request, reply) => {
-    endTimer(request, $ResponseBuilder);
-    // same as 'reply.getResponseTime()' but our approach
-    // helps us to make the code cleaner
-    endTimer(request, $RequestFullDuration);
+    try {
+      endTimer(request, $ResponseBuilder);
+      // same as 'reply.getResponseTime()' but our approach
+      // helps us to make the code cleaner
+      endTimer(request, $RequestFullDuration);
 
-    logClientRequest(request, reply);
+      logClientRequest(request, reply);
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
   });
 
   done();

--- a/src/server/utils/logging/fastifyPlugin.js
+++ b/src/server/utils/logging/fastifyPlugin.js
@@ -35,8 +35,9 @@ export const $RequestOverhead = Symbol('$RequestOverhead');
 export const $RouteHandler = Symbol('$RouteHandler');
 export const $ResponseBuilder = Symbol('$ResponseBuilder');
 
+const passThrough = ({ log }) => log;
 const UTILS = {
-  configureRequestLog: ({ log }) => log,
+  configureRequestLog: passThrough,
 };
 
 const getLocale = (req) => {
@@ -137,7 +138,7 @@ const logClientRequest = (request, reply) => {
   logger.info(configuredLog);
 };
 
-export const setConfigureRequestLog = (newConfigureRequestLog) => {
+export const setConfigureRequestLog = (newConfigureRequestLog = passThrough) => {
   UTILS.configureRequestLog = newConfigureRequestLog;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
if configureRequestLog is not provided by root module, request logs are not being logged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
re enable request logs
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Test suite and locally
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
