### PR TITLE
fix(csp-report): add application/csp-report content type support

### DIFF
--- a/__tests__/integration/__snapshots__/one-app.spec.js.snap
+++ b/__tests__/integration/__snapshots__/one-app.spec.js.snap
@@ -92,4 +92,4 @@ exports[`Tests that require Docker setup one-app successfully started metrics ha
 
 exports[`Tests that require Docker setup one-app successfully started one-app server provides reporting routes client reported errors logs errors when reported to /_/report/errors 1`] = `"reported client error"`;
 
-exports[`Tests that require Docker setup one-app successfully started one-app server provides reporting routes csp-violations reported to server logs violations reported to /_/report/errors 1`] = `"CSP Violation: {\\n  \\"csp-report\\": {\\n    \\"document-uri\\": \\"bad.example.com"`;
+exports[`Tests that require Docker setup one-app successfully started one-app server provides reporting routes csp-violations reported to server logs violations reported to /_/report/errors 1`] = `"CSP Violation: {\\"csp-report\\":{\\"document-uri\\":\\"bad.example.com"`;

--- a/__tests__/integration/one-app.spec.js
+++ b/__tests__/integration/one-app.spec.js
@@ -273,7 +273,7 @@ describe('Tests that require Docker setup', () => {
             ...defaultFetchOptions,
             method: 'POST',
             headers: {
-              'Content-Type': 'application/json',
+              'Content-Type': 'application/csp-report',
             },
             body: JSON.stringify({
               'csp-report': {

--- a/__tests__/server/ssrServer-requests.spec.js
+++ b/__tests__/server/ssrServer-requests.spec.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import ssrServer from '../../src/server/ssrServer';
+
+const { NODE_ENV } = process.env;
+const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+jest.mock('fastify-metrics', () => (_req, _opts, done) => done());
+
+describe('ssrServer route testing', () => {
+  afterAll(() => {
+    process.env.NODE_ENV = NODE_ENV;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('/_/status', async () => {
+    const server = await ssrServer();
+    const resp = await server.inject({
+      method: 'GET',
+      url: '/_/status',
+    });
+
+    expect(resp.statusCode).toEqual(200);
+    expect(resp.body).toEqual('OK');
+  });
+
+  describe('/_/report/security/csp-violation', () => {
+    describe('production', () => {
+      let server;
+      beforeAll(async () => {
+        process.env.NODE_ENV = 'production';
+        server = await ssrServer();
+      });
+
+      test('with csp-report', async () => {
+        const resp = await server.inject({
+          method: 'POST',
+          url: '/_/report/security/csp-violation',
+          headers: {
+            'Content-Type': 'application/csp-report',
+          },
+          payload: JSON.stringify({
+            'csp-report': {
+              'document-uri': 'bad.example.com',
+            },
+          }),
+        });
+        expect(warnSpy).toHaveBeenCalledWith('CSP Violation: {"csp-report":{"document-uri":"bad.example.com"}}');
+        expect(resp.statusCode).toEqual(204);
+      });
+
+      test('when csp-report is not provided', async () => {
+        const resp = await server.inject({
+          method: 'POST',
+          url: '/_/report/security/csp-violation',
+          headers: {
+            'Content-Type': 'application/csp-report',
+          },
+        });
+        expect(warnSpy).toHaveBeenCalledWith('CSP Violation: No data received!');
+        expect(resp.statusCode).toEqual(204);
+      });
+    });
+
+    describe('development', () => {
+      let server;
+      beforeAll(async () => {
+        process.env.NODE_ENV = 'development';
+        server = await ssrServer();
+      });
+
+      test('with csp-report', async () => {
+        const resp = await server.inject({
+          method: 'POST',
+          url: '/_/report/security/csp-violation',
+          headers: {
+            'Content-Type': 'application/csp-report',
+          },
+          payload: JSON.stringify({
+            'csp-report': {
+              'document-uri': 'bad.example.com',
+              'violated-directive': 'script-src',
+              'blocked-uri': 'blockedUri.example.com',
+              'line-number': '123',
+              'column-number': '432',
+              'source-file': 'sourceFile.js',
+            },
+          }),
+        });
+        expect(warnSpy).toHaveBeenCalledWith('CSP Violation: sourceFile.js:123:432 on page bad.example.com violated the script-src policy via blockedUri.example.com');
+        expect(resp.statusCode).toEqual(204);
+      });
+
+      test('when no csp-report', async () => {
+        const resp = await server.inject({
+          method: 'POST',
+          url: '/_/report/security/csp-violation',
+          headers: {
+            'Content-Type': 'application/csp-report',
+          },
+        });
+        expect(warnSpy).toHaveBeenCalledWith('CSP Violation reported, but no data received');
+        expect(resp.statusCode).toEqual(204);
+      });
+    });
+  });
+});

--- a/__tests__/server/ssrServer.spec.js
+++ b/__tests__/server/ssrServer.spec.js
@@ -107,6 +107,7 @@ describe('ssrServer', () => {
       setNotFoundHandler,
       setErrorHandler,
       ready,
+      addContentTypeParser: jest.fn(),
     }));
   });
 
@@ -325,7 +326,10 @@ describe('ssrServer', () => {
           }, null, jest.fn());
 
           const request = {
-            body: {},
+            headers: {
+              'Content-Type': 'application/csp-report',
+            },
+            body: JSON.stringify({}),
           };
           const reply = {
             status: jest.fn(() => reply),
@@ -353,7 +357,7 @@ describe('ssrServer', () => {
         }, null, jest.fn());
 
         const request = {
-          body: {
+          body: JSON.stringify({
             'csp-report': {
               'document-uri': 'document-uri',
               'violated-directive': 'violated-directive',
@@ -362,7 +366,7 @@ describe('ssrServer', () => {
               'column-number': 'column-number',
               'source-file': 'source-file',
             },
-          },
+          }),
         };
         const reply = {
           status: jest.fn(() => reply),
@@ -450,9 +454,9 @@ describe('ssrServer', () => {
 
           const request = {
             headers: {},
-            body: {
+            body: JSON.stringify({
               unit: 'testing',
-            },
+            }),
           };
           const reply = {
             status: jest.fn(() => reply),
@@ -462,9 +466,7 @@ describe('ssrServer', () => {
           post.mock.calls[0][1](request, reply);
 
           expect(post.mock.calls[0][0]).toEqual('/_/report/security/csp-violation');
-          expect(console.warn).toHaveBeenCalledWith(`CSP Violation: {
-  "unit": "testing"
-}`);
+          expect(console.warn).toHaveBeenCalledWith('CSP Violation: {"unit":"testing"}');
           expect(reply.status).toHaveBeenCalledWith(204);
           expect(reply.send).toHaveBeenCalled();
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
enable `application/csp-report` content type support.
Also included alternative pattern for testing `ssrServer`, this should reduce the reliance on integration tests as well as provide a slightly less mock heavy tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently CSP reports are failing due to unsupported content type.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Locally, unit and integration tests.


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [x] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
