### PR TITLE
fix(tracer): ending timers without starting would crash server

### DIFF
--- a/__tests__/server/utils/tracer.spec.js
+++ b/__tests__/server/utils/tracer.spec.js
@@ -24,6 +24,7 @@ import {
 } from '../../../src/server/utils/tracer';
 
 jest.spyOn(console, 'log');
+jest.spyOn(console, 'warn');
 jest.useFakeTimers().setSystemTime(new Date('1993-07-25'));
 jest.spyOn(process.hrtime, 'bigint');
 
@@ -162,6 +163,35 @@ describe('the tracer module', () => {
       expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`
         Array [
           "Trace: {\\"u\\":\\"-\\",\\"t\\":743558400000,\\"d\\":152,\\"f\\":{\\"1.url.com.example\\":{\\"s\\":12,\\"d\\":10,\\"em\\":\\"Error calling 1.url.com.example\\",\\"es\\":\\"mock Stack\\"},\\"2.url.com.example\\":{\\"s\\":12,\\"d\\":140,\\"em\\":\\"Error calling 2.url.com.example\\",\\"es\\":\\"mock Stack\\"},\\"3.url.com.example\\":{\\"s\\":122,\\"d\\":30,\\"em\\":\\"Error calling 3.url.com.example\\",\\"es\\":\\"mock Stack\\"}}} ",
+        ]
+      `);
+    });
+
+    it('should log a warning if tracer was stopped without being started', () => {
+      const tracer = new Tracer();
+      addMockHrTimeMs(12);
+
+      tracer.endFetchTimer('1.url.com.example');
+      expect(console.warn.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          "Tracer Error: endFetchTimer was called without startFetchTimer",
+        ]
+      `);
+      tracer.endFetchTimerWithError('1.url.com.example');
+      expect(console.warn.mock.calls[1]).toMatchInlineSnapshot(`
+        Array [
+          "Tracer Error: endFetchTimer was called without startFetchTimer",
+        ]
+      `);
+      expect(console.warn.mock.calls[2]).toMatchInlineSnapshot(`
+        Array [
+          "Tracer Error: endFetchTimerWithError was called without startFetchTimer",
+        ]
+      `);
+      tracer.endServerPhaseTimer('1');
+      expect(console.warn.mock.calls[3]).toMatchInlineSnapshot(`
+        Array [
+          "Tracer Error: endServerPhaseTimer was called without startServerPhaseTimer",
         ]
       `);
     });

--- a/src/server/utils/tracer.js
+++ b/src/server/utils/tracer.js
@@ -75,6 +75,10 @@ export class Tracer {
 
   // End a timer for a server phase
   endServerPhaseTimer = (serverPhasekey) => {
+    if (!this.#serverPhaseTimers[serverPhasekey]) {
+      console.warn('Tracer Error: endServerPhaseTimer was called without startServerPhaseTimer');
+      return;
+    }
     this.#serverPhaseTimers[serverPhasekey].endTimeNs = process.hrtime.bigint();
   }
 
@@ -87,12 +91,20 @@ export class Tracer {
 
   // End a timer for a fetch.
   endFetchTimer = (key) => {
+    if (!this.#fetchTimers[key]) {
+      console.warn('Tracer Error: endFetchTimer was called without startFetchTimer');
+      return;
+    }
     this.#fetchTimers[key].endTimeNs = process.hrtime.bigint();
   }
 
   // End a timer for a fetch with an error
   endFetchTimerWithError = (key, error) => {
     this.endFetchTimer(key);
+    if (!this.#fetchTimers[key]) {
+      console.warn('Tracer Error: endFetchTimerWithError was called without startFetchTimer');
+      return;
+    }
     this.#fetchTimers[key].error = error;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If you ended a timer without first starting it, it would throw an error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While testing the redirectAllowList, I found that if you throw an error within [createRequestHtmlFragment](https://github.com/americanexpress/one-app/blob/5.x.x/src/server/middleware/createRequestHtmlFragment.jsx) before starting serverPhaseTimer 7, the error would get caught and attempt to end timer 7. This would end up throwing an error outside of a try/catch and crash the server

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with the same method used to find this error, throwing an error in the redirect flow an ensuring the server didn't crash.

Also unit tested

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
