### PR TITLE
feat(styleLoader): aggregate stylesheets and dedupe if already loaded

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # which includes build utils preinstalled (e.g. gcc, make, etc).
 # This will result in faster and reliable One App docker image
 # builds as we do not have to run apk installs for alpine.
-FROM node:18.17.0 as builder
+FROM node:18.17.1 as builder
 WORKDIR /opt/build
 RUN npm install -g npm@9.6.7 --registry=https://registry.npmjs.org
 COPY --chown=node:node ./ /opt/build
@@ -29,7 +29,7 @@ RUN NODE_ENV=production npm run build && \
 
 # development image
 # docker build . --target=development
-FROM node:18.17.0-alpine as development
+FROM node:18.17.1-alpine as development
 ARG USER
 ENV USER ${USER:-node}
 ENV NODE_ENV=development
@@ -47,7 +47,7 @@ COPY --from=builder --chown=node:node /opt/one-app/development ./
 
 # production image
 # last so that it's the default image artifact
-FROM node:18.17.0-alpine as production
+FROM node:18.17.1-alpine as production
 ARG USER
 ENV USER ${USER:-node}
 ENV NODE_ENV=production

--- a/__tests__/server/utils/__snapshots__/renderModuleStyles.spec.js.snap
+++ b/__tests__/server/utils/__snapshots__/renderModuleStyles.spec.js.snap
@@ -1,7 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderModuleStyles should handle a mix of modules with and without SSR styles 1`] = `"<style class="ssr-css">.test-module-b_class { color: red; }</style><style class="ssr-css">.test-module-d_class { color: red; }</style>"`;
+exports[`renderModuleStyles should deduplicate aggregatedStyles that have the same digest hash 1`] = `
+"
+<style id="shared_hash_deps" data-ssr="true">
+  .test-module-a_deps { color: blue; }
+</style>
+<style id="shared_hash_local" data-ssr="true">
+  .test-module-a_local { color: rebeccapurple; }
+</style>
+<style id="unique-hash_deps" data-ssr="true">
+  .test-module-c_deps { color: blue; }
+</style>
+<style id="unique-hash_local" data-ssr="true">
+  .test-module-c_local { color: rebeccapurple; }
+</style>"
+`;
+
+exports[`renderModuleStyles should handle a mix of modules with and without SSR styles 1`] = `
+"<style class="ssr-css">.test-module-b_class { color: red; }</style><style class="ssr-css">.test-module-d_class { color: red; }</style>
+<style id="test-module-e_deps" data-ssr="true">
+  .test-module-e_deps { color: blue; }
+</style>
+<style id="test-module-e_local" data-ssr="true">
+  .test-module-e_local { color: rebeccapurple; }
+</style>"
+`;
 
 exports[`renderModuleStyles should handle modules with SSR styles 1`] = `"<style class="ssr-css">.test-module_class { color: red; }</style>"`;
 
-exports[`renderModuleStyles should not send empty styles 1`] = `"<style class="ssr-css">.test-module-b_class { color: red; }</style>"`;
+exports[`renderModuleStyles should handle modules with aggregated SSR styles 1`] = `
+"
+<style id="test-module_deps" data-ssr="true">
+  .test-module_deps { color: blue; }
+</style>
+<style id="test-module_local" data-ssr="true">
+  .test-module_local { color: rebeccapurple; }
+</style>"
+`;
+
+exports[`renderModuleStyles should not send empty styles 1`] = `
+"<style class="ssr-css">.test-module-b_class { color: red; }</style>
+<style id="test-module-d_deps" data-ssr="true">
+  .test-module-d_deps { color: blue; }
+</style>
+<style id="test-module-d_local" data-ssr="true">
+  .test-module-d_local { color: rebeccapurple; }
+</style>"
+`;

--- a/__tests__/server/utils/__snapshots__/renderModuleStyles.spec.js.snap
+++ b/__tests__/server/utils/__snapshots__/renderModuleStyles.spec.js.snap
@@ -1,49 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderModuleStyles should deduplicate aggregatedStyles that have the same digest hash 1`] = `
-"
-<style id="shared_hash_deps" data-ssr="true">
-  .test-module-a_deps { color: blue; }
-</style>
-<style id="shared_hash_local" data-ssr="true">
-  .test-module-a_local { color: rebeccapurple; }
-</style>
-<style id="unique-hash_deps" data-ssr="true">
-  .test-module-c_deps { color: blue; }
-</style>
-<style id="unique-hash_local" data-ssr="true">
-  .test-module-c_local { color: rebeccapurple; }
-</style>"
-`;
+exports[`renderModuleStyles should deduplicate aggregatedStyles that have the same digest hash 1`] = `"<style id="shared_hash_deps" data-ssr="true">.test-module-a_deps { color: blue; }</style><style id="shared_hash_local" data-ssr="true">.test-module-a_local { color: rebeccapurple; }</style><style id="unique-hash_deps" data-ssr="true">.test-module-c_deps { color: blue; }</style><style id="unique-hash_local" data-ssr="true">.test-module-c_local { color: rebeccapurple; }</style>"`;
 
-exports[`renderModuleStyles should handle a mix of modules with and without SSR styles 1`] = `
-"<style class="ssr-css">.test-module-b_class { color: red; }</style><style class="ssr-css">.test-module-d_class { color: red; }</style>
-<style id="test-module-e_deps" data-ssr="true">
-  .test-module-e_deps { color: blue; }
-</style>
-<style id="test-module-e_local" data-ssr="true">
-  .test-module-e_local { color: rebeccapurple; }
-</style>"
-`;
+exports[`renderModuleStyles should handle a mix of modules with and without SSR styles 1`] = `"<style class="ssr-css">.test-module-b_class { color: red; }</style><style class="ssr-css">.test-module-d_class { color: red; }</style><style id="test-module-e_deps" data-ssr="true">.test-module-e_deps { color: blue; }</style><style id="test-module-e_local" data-ssr="true">.test-module-e_local { color: rebeccapurple; }</style>"`;
 
 exports[`renderModuleStyles should handle modules with SSR styles 1`] = `"<style class="ssr-css">.test-module_class { color: red; }</style>"`;
 
-exports[`renderModuleStyles should handle modules with aggregated SSR styles 1`] = `
-"
-<style id="test-module_deps" data-ssr="true">
-  .test-module_deps { color: blue; }
-</style>
-<style id="test-module_local" data-ssr="true">
-  .test-module_local { color: rebeccapurple; }
-</style>"
-`;
+exports[`renderModuleStyles should handle modules with aggregated SSR styles 1`] = `"<style id="test-module_deps" data-ssr="true">.test-module_deps { color: blue; }</style><style id="test-module_local" data-ssr="true">.test-module_local { color: rebeccapurple; }</style>"`;
 
-exports[`renderModuleStyles should not send empty styles 1`] = `
-"<style class="ssr-css">.test-module-b_class { color: red; }</style>
-<style id="test-module-d_deps" data-ssr="true">
-  .test-module-d_deps { color: blue; }
-</style>
-<style id="test-module-d_local" data-ssr="true">
-  .test-module-d_local { color: rebeccapurple; }
-</style>"
-`;
+exports[`renderModuleStyles should not send empty styles 1`] = `"<style class="ssr-css">.test-module-b_class { color: red; }</style><style id="test-module-d_deps" data-ssr="true">.test-module-d_deps { color: blue; }</style><style id="test-module-d_local" data-ssr="true">.test-module-d_local { color: rebeccapurple; }</style>"`;

--- a/src/server/utils/renderModuleStyles.js
+++ b/src/server/utils/renderModuleStyles.js
@@ -28,11 +28,10 @@ const generateStyleTag = ({ css, digest }) => `
 const generateServerStyleTag = (css) => `<style class="ssr-css">${css}</style>`;
 
 const filterOutDuplicateDigests = (sheet, existingDigests) => sheet
-  .filter(({ css, digest }) => css && digest && !existingDigests.has(digest))
-  .map((styles) => {
-    existingDigests.add(styles.digest);
-    return styles;
-  });
+  .filter(({ css, digest }) => css && digest && !existingDigests.has(digest));
+
+const updateExistingDigests = (filteredSheets, existingDigests) => filteredSheets
+  .forEach((sheet) => { existingDigests.add(sheet.digest); });
 
 export default function renderModuleStyles(store) {
   const existingDigests = new Set();
@@ -52,11 +51,14 @@ export default function renderModuleStyles(store) {
       }
 
       const { aggregatedStyles } = module.ssrStyles;
+      const uniqueStyles = filterOutDuplicateDigests(aggregatedStyles, existingDigests);
+      updateExistingDigests(uniqueStyles, existingDigests);
+
       return {
         ...acc,
         aggregated: [
           ...acc.aggregated,
-          ...filterOutDuplicateDigests(aggregatedStyles, existingDigests),
+          ...uniqueStyles,
         ],
       };
     }, { aggregated: [], legacy: [] });

--- a/src/server/utils/renderModuleStyles.js
+++ b/src/server/utils/renderModuleStyles.js
@@ -20,10 +20,7 @@ import { getModule } from 'holocron';
  * Generates a style tag with unique ID attribute per CSS file loaded.
  * @returns {string}
  */
-const generateStyleTag = ({ css, digest }) => `
-<style id="${digest}" data-ssr="true">
-  ${css}
-</style>`;
+const generateStyleTag = ({ css, digest }) => `<style id="${digest}" data-ssr="true">${css}</style>`;
 
 const generateServerStyleTag = (css) => `<style class="ssr-css">${css}</style>`;
 
@@ -44,10 +41,15 @@ export default function renderModuleStyles(store) {
       // Backwards compatibility for older bundles.
       if (!module.ssrStyles.aggregatedStyles) {
         const ssrStylesFullSheet = module.ssrStyles.getFullSheet();
-        if (ssrStylesFullSheet) {
-          acc.legacy.push({ css: ssrStylesFullSheet });
-        }
-        return acc;
+        return {
+          ...acc,
+          legacy: ssrStylesFullSheet
+            ? [
+              ...acc.legacy,
+              { css: ssrStylesFullSheet },
+            ]
+            : acc.legacy,
+        };
       }
 
       const { aggregatedStyles } = module.ssrStyles;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR:

- fixes a cascade ordering issue between server and client bundles, leading to style inconsistencies when hydrated.
- enables deduplication between modules for identical styles, i.e. if a component library imports styles via css modules.
- provides the ability for SSR generated styles to directly match the expected output of CSR styles, preventing a flash of restyling as the browser processes the Recalculate Styles task.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When using a component library (or any dependency) that imports styles via CSS Modules, the bundler output generates a server bundle that is inconsistent with the client side bundle, as well as resulting in it being difficult to provide style overrides without resorting to CSS hacks (like !important).

In order to resolve this and match the client side bundle output it's necessary to split the styles into multiple style tags, and then order them to allow for cascade overrides. However, the OneApp styles loader currently wraps all SSR styles in a single style tag.

This change retains the existing functionality in order to provide backwards compatibility for modules generated with older bundlers, whilst allowing for bundlers to provide a new key: `aggregatedStyles`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Generated a root module and three child modules that share a component library dependency, with each child module rendering two instances of the same component. The first one unchanged, the second with style overrides applied.

Multiple modules helped to prove that deduplication happened as intended, with only a single instance of the component library styles being rendered, with overrides applying with the expected cascade priority.

This was additionally run with an older version of OneApp, and an older bundle to prove backwards compatibility is unaffected.

<img width="933" alt="Screenshot 2023-08-29 at 16 10 37" src="https://github.com/americanexpress/one-app/assets/9933592/af05e6db-fb94-4f86-9aea-a8e01ea3b8d2">

<img width="710" alt="Screenshot 2023-08-29 at 22 30 17" src="https://github.com/americanexpress/one-app/assets/9933592/66d2d22e-8dfe-4fdc-afb5-6908c1ac5592">


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->

This allows developers to provide overrides to styles imported via CSS modules within their applications without resorting to CSS hacks and forcing specificity.

