### PR TITLE
fix(cache-cdn): stringify object

### DIFF
--- a/__tests__/server/utils/cdnCache.spec.js
+++ b/__tests__/server/utils/cdnCache.spec.js
@@ -107,7 +107,7 @@ describe('cacheUtils', () => {
       expect(logSpy).toHaveBeenCalledWith(`Creating ${cacheFileName}`);
       expect(fsPromises.writeFile).toHaveBeenCalledWith(
         oneAppModuleCachePath,
-        JSON.stringify('{}')
+        JSON.stringify({})
       );
       expect(logSpy).toHaveBeenCalledWith(`${cacheFileName} created successfully on ${oneAppModuleCachePath}`);
       expect(errorSpy).not.toHaveBeenCalled();

--- a/src/server/utils/cdnCache.js
+++ b/src/server/utils/cdnCache.js
@@ -47,7 +47,7 @@ export const setupCacheFile = async () => {
     console.log(`Successfully created ${oneAppDirectoryPath}`);
     console.log(`Creating ${cacheFileName}`);
     try {
-      await fsPromises.writeFile(oneAppModuleCachePath, JSON.stringify('{}'));
+      await fsPromises.writeFile(oneAppModuleCachePath, JSON.stringify({}));
       console.log(`${cacheFileName} created successfully on ${oneAppModuleCachePath}`);
     } catch (error) {
       console.error(`Error creating ${cacheFileName} on ${oneAppModuleCachePath}, \n${error}`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix initialization of cache object and stringify.
`JSON.stringify('{}')` to `JSON.stringify({})`
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It caused caching issue, as it was trying to key value in string instead of object.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
