### PR TITLE
chore(workflows): use GITHUB_OUTPUT instead of ::set-output

### DIFF
--- a/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
+++ b/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
           if [[ "${{github.event_name == 'pull_request'}}" == "true" ]]
           then
-            echo ::set-output name=short_ref::${{github.base_ref}}
+            echo "short_ref=${{github.base_ref}}" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=short_ref::${{github.ref_name}}
+            echo "short_ref=${{github.ref_name}}" >> $GITHUB_OUTPUT
           fi
       - name: npm commit lint
         run: npm run test:git-history -- --from origin/${{ steps.vars.outputs.short_ref }}

--- a/.github/workflows/release-step-2_automatic_tag-release.yml
+++ b/.github/workflows/release-step-2_automatic_tag-release.yml
@@ -18,12 +18,12 @@ jobs:
         shell: bash
         run: |
           commitmessage=$(git log --format=%s -n 1 ${{ github.event.after }})
-          echo ::set-output name=message::"\"$commitmessage"\"
+          echo "message="\"$commitmessage"\"" >> $GITHUB_OUTPUT
           echo ${{ steps.get-commit-message.outputs.message }}
       - name: get tag version
         id: get-tag-version
         run: |
-          echo ::set-output name=tagversion::$( egrep -o '([0-9]+\.){2}(\*|[0-9]+)(-\S*)?' <<< ${{ steps.get-commit-message.outputs.message }} )
+          echo "tagversion=$( egrep -o '([0-9]+\.){2}(\*|[0-9]+)(-\S*)?' <<< ${{ steps.get-commit-message.outputs.message }} )" >> $GITHUB_OUTPUT
           echo v${{ steps.get-tag-version.outputs.tagversion }}
       - name: set tag version
         id: set-tag-version
@@ -33,7 +33,7 @@ jobs:
           echo ${{ steps.get-tag-version.outputs.tagversion }}
           git tag v${{ steps.get-tag-version.outputs.tagversion }}
           git push origin --tags
-          echo ::set-output name=action_tag::v${{ steps.get-tag-version.outputs.tagversion }}
+          echo "action_tag=v${{ steps.get-tag-version.outputs.tagversion }}" >> $GITHUB_OUTPUT
       - name: Trigger Image Publishing
         uses: octokit/request-action@v2.x
         id: dispatch_release-step-3_automatic_prepare-docker-tags

--- a/.github/workflows/release-step-3_automatic_prepare-docker-tags.yml
+++ b/.github/workflows/release-step-3_automatic_prepare-docker-tags.yml
@@ -29,13 +29,13 @@ jobs:
           #Checks for when a valid tag is manually pushed
           if [[ $GITHUB_REF != "" && "${{ github.event.client_payload.tagversion }}" == "" ]];
           then
-          echo ::set-output name=tagversion::$(egrep -o '^v([0-9]+\.[0-9]+\.[0-9]+)(-\S*)?' <<< $GITHUB_REF)
+          echo "tagversion=$(egrep -o '^v([0-9]+\.[0-9]+\.[0-9]+)(-\S*)?' <<< $GITHUB_REF)" >> $GITHUB_OUTPUT
           else
-          echo ::set-output name=tagversion::${{ github.event.client_payload.tagversion }}
+          echo "tagversion=${{ github.event.client_payload.tagversion }}" >> $GITHUB_OUTPUT
           fi
           if [[ "${{ github.event.inputs.tag_version }}" != "" ]]
           then
-          echo ::set-output name=tagversion::${{ github.event.inputs.tag_version }}
+          echo "tagversion=${{ github.event.inputs.tag_version }}" >> $GITHUB_OUTPUT
           fi
           echo $tagversion
       - name: Normalize meta tag
@@ -44,16 +44,16 @@ jobs:
           # if a meta tag was specified this was a manual build
           if [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
           then
-          echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}
+          echo "metatag=${{ github.event.inputs.docker_meta_tag }}" >> $GITHUB_OUTPUT
           echo From manual run: ${{ github.event.inputs.docker_meta_tag }}
           # if we are on the main branch, default to `latest`
           elif [[ "$GITHUB_REF" == "refs/heads/main" ]]
           then
-          echo ::set-output name=metatag::latest
+          echo "metatag=latest" >> $GITHUB_OUTPUT
           echo For main branch: latest
           # if we are not on the main branch, default to `do_not_tag`
           else
-          echo ::set-output name=metatag::do_not_tag
+          echo "metatag=do_not_tag" >> $GITHUB_OUTPUT
           echo For other branch: do_not_tag
           fi
       - name: Check Tag Version
@@ -67,7 +67,7 @@ jobs:
         run: |
           # trimmed off 'v' from tagversion
           tagversion=${{ steps.set_tag_version.outputs.tagversion }}
-          echo ::set-output name=dockertag::$(sed 's/^v*//' <<< "$tagversion")
+          echo "dockertag=$(sed 's/^v*//' <<< "$tagversion")" >> $GITHUB_OUTPUT
       # ensure tag is available
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
+++ b/.github/workflows/release-step-4_automatic_docker-prod-build-and-publish.yml
@@ -26,23 +26,23 @@ jobs:
             MAJOR="$(echo ${{ github.event.client_payload.docker_tag_version}} | cut -d'.' -f1)"
             MINOR="$(echo ${{ github.event.client_payload.docker_tag_version}} | cut -d'.' -f2)"
             PATCH="$(echo ${{ github.event.client_payload.docker_tag_version}} | cut -d'.' -f3)"
-            echo ::set-output name=major_version::${MAJOR}
-            echo ::set-output name=minor_version::${MINOR}
+            echo "major_version=${MAJOR}" >> $GITHUB_OUTPUT
+            echo "minor_version=${MINOR}" >> $GITHUB_OUTPUT
       - name: Docker Image Versions
         id: set_docker_version
         run: |
           #Runs when the action is triggered by the dispatch function
           if [[ "${{ github.event.inputs.docker_tag_version }}" == "" ]]; then
-          echo ::set-output name=docker_version::${{ github.event.client_payload.docker_tag_version }}
-          echo ::set-output name=major_version::${{ steps.get_sem_version.outputs.major_version }}
-          echo ::set-output name=minor_version::${{ steps.get_sem_version.outputs.minor_version }}
+          echo "docker_version=${{ github.event.client_payload.docker_tag_version }}" >> $GITHUB_OUTPUT
+          echo "major_version=${{ steps.get_sem_version.outputs.major_version }}" >> $GITHUB_OUTPUT
+          echo "minor_version=${{ steps.get_sem_version.outputs.minor_version }}" >> $GITHUB_OUTPUT
           else
           #Runs when a tag is triggered manually
-          echo ::set-output name=docker_version::${{ github.event.inputs.docker_tag_version }}
+          echo "docker_version=${{ github.event.inputs.docker_tag_version }}" >> $GITHUB_OUTPUT
           MAJOR="$(echo ${{ github.event.inputs.docker_tag_version}} | cut -d'.' -f1)"
           MINOR="$(echo ${{ github.event.inputs.docker_tag_version}} | cut -d'.' -f2)"
-          echo ::set-output name=major_version::${MAJOR}
-          echo ::set-output name=minor_version::${MINOR}
+          echo "major_version=${MAJOR}" >> $GITHUB_OUTPUT
+          echo "minor_version=${MINOR}" >> $GITHUB_OUTPUT
           fi
       - name: Normalize meta tag
         id: set_docker_meta_tag
@@ -50,21 +50,21 @@ jobs:
           # Always use the value from the last step if it is present
           if [[ "${{ github.event.client_payload.docker_meta_tag }}" != "" ]]
           then
-          echo ::set-output name=metatag::${{ github.event.client_payload.docker_meta_tag }}
+          echo "metatag=${{ github.event.client_payload.docker_meta_tag }}" >> $GITHUB_OUTPUT
           echo From previous step: ${{ github.event.client_payload.docker_meta_tag }}
           # if a meta tag was specified this was a manual build
           elif [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
           then
-          echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}
+          echo "metatag=${{ github.event.inputs.docker_meta_tag }}" >> $GITHUB_OUTPUT
           echo From manual run: ${{ github.event.inputs.docker_meta_tag }}
           # if we are on the main branch, default to `latest`
           elif [[ "$GITHUB_REF" == "refs/heads/main" ]]
           then
-          echo ::set-output name=metatag::latest
+          echo "metatag=latest" >> $GITHUB_OUTPUT
           echo For main branch: latest
           # if we are not on the main branch, default to `do_not_tag`
           else
-          echo ::set-output name=metatag::do_not_tag
+          echo "metatag=do_not_tag" >> $GITHUB_OUTPUT
           echo For other branch: do_not_tag
           fi
       - uses: actions/checkout@v3

--- a/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
+++ b/.github/workflows/release-step-5_automatic_docker-dev-build-and-publish.yml
@@ -25,16 +25,16 @@ jobs:
         run: |
           #Runs when the action is triggered by the dispatch function
           if [[ "${{ github.event.inputs.docker_tag_version }}" == "" ]]; then
-          echo ::set-output name=docker_version::${{ github.event.client_payload.docker_tag_version }}
-          echo ::set-output name=major_version::${{ github.event.client_payload.major_version }}
-          echo ::set-output name=minor_version::${{ github.event.client_payload.minor_version }}
+          echo "docker_version=${{ github.event.client_payload.docker_tag_version }}" >> $GITHUB_OUTPUT
+          echo "major_version=${{ github.event.client_payload.major_version }}" >> $GITHUB_OUTPUT
+          echo "minor_version=${{ github.event.client_payload.minor_version }}" >> $GITHUB_OUTPUT
           else
           #Runs when a tag is triggered manually
-          echo ::set-output name=docker_version::${{ github.event.inputs.docker_tag_version }}
+          echo "docker_version=${{ github.event.inputs.docker_tag_version }}" >> $GITHUB_OUTPUT
           MAJOR="$(echo ${{ github.event.inputs.docker_tag_version}} | cut -d'.' -f1)"
           MINOR="$(echo ${{ github.event.inputs.docker_tag_version}} | cut -d'.' -f2)"
-          echo ::set-output name=major_version::${MAJOR}
-          echo ::set-output name=minor_version::${MINOR}
+          echo "major_version=${MAJOR}" >> $GITHUB_OUTPUT
+          echo "minor_version=${MINOR}" >> $GITHUB_OUTPUT
           fi
       - name: Normalize meta tag
         id: set_docker_meta_tag
@@ -42,21 +42,21 @@ jobs:
           # Always use the value from the last step if it is present
           if [[ "${{ github.event.client_payload.docker_meta_tag }}" != "" ]]
           then
-          echo ::set-output name=metatag::${{ github.event.client_payload.docker_meta_tag }}
+          echo "metatag=${{ github.event.client_payload.docker_meta_tag }}" >> $GITHUB_OUTPUT
           echo From previous step: ${{ github.event.client_payload.docker_meta_tag }}
           # if a meta tag was specified this was a manual build
           elif [[ "${{ github.event.inputs.docker_meta_tag }}" != "" ]]
           then
-          echo ::set-output name=metatag::${{ github.event.inputs.docker_meta_tag }}
+          echo "metatag=${{ github.event.inputs.docker_meta_tag }}" >> $GITHUB_OUTPUT
           echo From manual run: ${{ github.event.inputs.docker_meta_tag }}
           # if we are on the main branch, default to `latest`
           elif [[ "$GITHUB_REF" == "refs/heads/main" ]]
           then
-          echo ::set-output name=metatag::latest
+          echo "metatag=latest" >> $GITHUB_OUTPUT
           echo For main branch: latest
           # if we are not on the main branch, default to `do_not_tag`
           else
-          echo ::set-output name=metatag::do_not_tag
+          echo "metatag=do_not_tag" >> $GITHUB_OUTPUT
           echo For other branch: do_not_tag
           fi
       - name: Print docker version

--- a/.github/workflows/release-step-6-automatic_publish-one-app-statics-to-npm.yml
+++ b/.github/workflows/release-step-6-automatic_publish-one-app-statics-to-npm.yml
@@ -17,9 +17,9 @@ jobs:
         run: |
           if [[ "${{ github.event.inputs.tag_version }}" == "" ]]
           then
-          echo ::set-output name=tagversion::${{ github.event.client_payload.docker_tag_version }}
+          echo "tagversion=${{ github.event.client_payload.docker_tag_version }}" >> $GITHUB_OUTPUT
           else
-          echo ::set-output name=tagversion::${{ github.event.inputs.tag_version }}
+          echo "tagversion=${{ github.event.inputs.tag_version }}" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
replace
```shell
echo "::set-output name={name}::{value}"
```
with
```shell
echo "{name}={value}" >> $GITHUB_OUTPUT
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
these are now showing as warnings in the runs, e.g. https://github.com/americanexpress/one-app/actions/runs/6344142425

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I guess we'll see a run of [.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml](https://github.com/americanexpress/one-app/pull/1141/files#diff-3d711afca65f83d28d66cf77532c7acac0f14c39b4aa56d650686873a35065f6) on this PR 🤞 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [x] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
None