### PR TITLE
fix(scripts): start watch failed to fetch modules - v5

### DIFF
--- a/scripts/watch-server.js
+++ b/scripts/watch-server.js
@@ -50,6 +50,7 @@ const buildServiceWorkerScripts = require('./build-service-workers');
   ].find((argName) => arg.startsWith(argName)));
 
   const nodemon = spawn('nodemon', [
+    '--dns-result-order=ipv4first', '--no-experimental-fetch',
     '--signal', 'SIGTERM', '--watch', 'src', '--ext', 'js,jsx', 'lib/server/index.js',
   ].concat(flags.length > 0 ? ['--', ...flags] : []), {
     stdio: 'inherit',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed watch server script

## Motivation and Context

`npm run start:watch` failed to fetch any modules

## How Has This Been Tested?

`npm run start:watch` now successfully starts the server

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Can use watch mode again while developing one-app
