### PR TITLE
fix(runTime): use relative urls for defaulted report variables

### DIFF
--- a/__tests__/server/config/env/runTime.spec.js
+++ b/__tests__/server/config/env/runTime.spec.js
@@ -357,8 +357,7 @@ describe('runTime', () => {
 
     it('has a default value for development', () => {
       process.env.NODE_ENV = 'development';
-      expect(clientReportingUrl.defaultValue()).toBeDefined();
-      expect(clientReportingUrl.defaultValue()).toMatch(/^https?:\/\//);
+      expect(clientReportingUrl.defaultValue()).toBe('/_/report/errors');
     });
 
     it('has no default value for production', () => {
@@ -372,8 +371,7 @@ describe('runTime', () => {
 
     it('has a default value for development', () => {
       process.env.NODE_ENV = 'development';
-      expect(clientCSPReportingUrl.defaultValue()).toBeDefined();
-      expect(clientCSPReportingUrl.defaultValue()).toMatch(/^https?:\/\//);
+      expect(clientCSPReportingUrl.defaultValue()).toBe('/_/report/security/csp-violation');
     });
 
     it('has no default value for production', () => {

--- a/src/server/config/env/runTime.js
+++ b/src/server/config/env/runTime.js
@@ -149,7 +149,7 @@ const runTime = [
   {
     name: 'ONE_CLIENT_REPORTING_URL',
     defaultValue: () => (process.env.NODE_ENV === 'development'
-      ? `http://${ip}:${process.env.HTTP_PORT}/_/report/errors`
+      ? '/_/report/errors'
       : undefined),
     validate: isFetchableUrlInBrowser,
   },
@@ -157,7 +157,7 @@ const runTime = [
   {
     name: 'ONE_CLIENT_CSP_REPORTING_URL',
     defaultValue: () => (process.env.NODE_ENV === 'development'
-      ? `http://${ip}:${process.env.HTTP_PORT}/_/report/security/csp-violation`
+      ? '/_/report/security/csp-violation'
       : undefined),
     validate: isFetchableUrlInBrowser,
   },


### PR DESCRIPTION
## Description
Changes the default development ONE_CLIENT_REPORTING_URL and ONE_CLIENT_CSP_REPORTING_URL to use relative URLs instead of URLs with a hostname.

## Motivation and Context
Fixes #1193 by not using the internal docker IP address.

## How Has This Been Tested?
Ran locally with one-app-runner using these updated variables and verified that report endpoints responded with 204 and printed reports to console.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
When running in Docker, Javascript errors should be printed to the console rather than not being reported.
