### PR TITLE
chore(package): set engines to accurately represent node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "One Amex SPA technology stack.",
   "main": "index.js",
   "engines": {
-    "node": ">=16",
+    "node": ">=16 <=18",
     "npm": ">=8"
   },
   "scripts": {


### PR DESCRIPTION
Our engines field doesn't accurately represent the Node versions we support. 
This fixes that by making it obvious that we only support 16 -> 18