### PR TITLE
refactor(otel): remove unnecessary log on startup in prod

### DIFF
--- a/__tests__/server/utils/logging/config/otel.spec.js
+++ b/__tests__/server/utils/logging/config/otel.spec.js
@@ -125,14 +125,12 @@ describe('OpenTelemetry logging', () => {
       expect(pino.transport.mock.calls[0][0]).toMatchInlineSnapshot(`
         {
           "options": {
-            "logRecordProcessorOptions": [
-              {
-                "exporterOptions": {
-                  "protocol": "grpc",
-                },
-                "recordProcessorType": "batch",
+            "logRecordProcessorOptions": {
+              "exporterOptions": {
+                "protocol": "grpc",
               },
-            ],
+              "recordProcessorType": "batch",
+            },
             "loggerName": "Mock Service Name",
             "messageKey": "message",
             "resourceAttributes": {
@@ -180,14 +178,12 @@ describe('OpenTelemetry logging', () => {
     expect(pino.transport).toHaveBeenCalledTimes(1);
     expect(pino.transport.mock.calls[0][0].options.logRecordProcessorOptions)
       .toMatchInlineSnapshot(`
-      [
-        {
-          "exporterOptions": {
-            "protocol": "grpc",
-          },
-          "recordProcessorType": "batch",
+      {
+        "exporterOptions": {
+          "protocol": "grpc",
         },
-      ]
+        "recordProcessorType": "batch",
+      }
     `);
     expect(pino.transport.mock.results[0].value).toBe(transport);
   });

--- a/src/server/utils/logging/config/otel.js
+++ b/src/server/utils/logging/config/otel.js
@@ -53,16 +53,16 @@ export function createOtelTransport() {
     };
   }, {}) : {};
 
-  const logRecordProcessorOptions = [{
+  let logRecordProcessorOptions = {
     recordProcessorType: 'batch',
     exporterOptions: { protocol: 'grpc' },
-  }];
+  };
 
   if (process.env.NODE_ENV === 'development') {
-    logRecordProcessorOptions.push({
+    logRecordProcessorOptions = [logRecordProcessorOptions, {
       recordProcessorType: 'simple',
       exporterOptions: { protocol: 'console' },
-    });
+    }];
   }
 
   return pino.transport({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Give the OTel pino transport an object instead of an array with a single entry when in production

## Motivation and Context

Relates to Vunovati/pino-opentelemetry-transport#106

Currently startup in production results in a log to STDOUT that is not useful

```
MultiLogRecordProcessor [
  <ref *1> BatchLogRecordProcessor {
    _exporter: OTLPLogExporter {
      _sendingPromises: [],
      url: '0.0.0.0:4317',
      shutdown: [Function: bound shutdown],
      _shutdownOnce: [BindOnceFuture],
      _concurrencyLimit: Infinity,
      timeoutMillis: 10000,
      grpcQueue: [],
      serviceClient: undefined,
      metadata: [Metadata],
      compression: 0
    },
    _finishedLogRecords: [],
    _maxExportBatchSize: 512,
    _maxQueueSize: 2048,
    _scheduledDelayMillis: 5000,
    _exportTimeoutMillis: 30000,
    _shutdownOnce: BindOnceFuture {
      _callback: [AsyncFunction: _shutdown],
      _that: [Circular *1],
      _isCalled: false,
      _deferred: [Deferred]
    }
  }
]
```

With this change, the log still exists in development and when running tests but is unavoidable until the linked issue is addressed.

## How Has This Been Tested?

Ran app locally with and without change and saw that in both dev and prod configuration logs were successfully sent to local collector and the extraneous log no longer appears on startup in production

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Removes confusing, unexpected log