### PR TITLE
fix(ssrServer): fastify scope resulted in hooks being called more than once

### DIFF
--- a/__tests__/server/ssrServer.spec.js
+++ b/__tests__/server/ssrServer.spec.js
@@ -86,30 +86,33 @@ afterAll(() => {
 });
 
 describe('ssrServer', () => {
-  let register;
-  let setNotFoundHandler;
-  let setErrorHandler;
-  let ready;
+  const mockFastifyInstance = {
+    register: jest.fn(async (plugin) => {
+      plugin(mockFastifyInstance, null, jest.fn());
+    }),
+    setNotFoundHandler: jest.fn(),
+    setErrorHandler: jest.fn(),
+    ready: jest.fn(),
+    addContentTypeParser: jest.fn(),
+    get: jest.fn(),
+    post: jest.fn(),
+  };
+  const {
+    setNotFoundHandler,
+    setErrorHandler,
+    ready,
+    get,
+    post,
+    register,
+  } = mockFastifyInstance;
+
+  Fastify.mockImplementation(() => mockFastifyInstance);
 
   beforeEach(() => {
-    // jest.resetModules();
     jest.clearAllMocks();
     process.env.NODE_ENV = 'development';
     delete process.env.ONE_ENABLE_POST_TO_MODULE_ROUTES;
     delete process.env.ONE_MAX_POST_REQUEST_PAYLOAD;
-
-    register = jest.fn();
-    setNotFoundHandler = jest.fn();
-    setErrorHandler = jest.fn();
-    ready = jest.fn();
-
-    Fastify.mockImplementationOnce(() => ({
-      register,
-      setNotFoundHandler,
-      setErrorHandler,
-      ready,
-      addContentTypeParser: jest.fn(),
-    }));
   });
 
   test('builds the fastify server and registers plugins in the correct order', async () => {
@@ -122,13 +125,13 @@ describe('ssrServer', () => {
       disableRequestLogging: true,
     });
 
-    expect(register).toHaveBeenCalledTimes(13);
-    expect(register.mock.calls[0][0]).toEqual(fastifySensible);
-    expect(register.mock.calls[1][0]).toEqual(ensureCorrelationId);
-    expect(register.mock.calls[2][0]).toEqual(fastifyCookie);
-    expect(register.mock.calls[3][0]).toEqual(logging);
-    expect(register.mock.calls[4][0]).toEqual(fastifyMetrics);
-    expect(register.mock.calls[5]).toEqual([
+    expect(register).toHaveBeenCalledTimes(22);
+    expect(register.mock.calls[1][0]).toEqual(fastifySensible);
+    expect(register.mock.calls[2][0]).toEqual(ensureCorrelationId);
+    expect(register.mock.calls[3][0]).toEqual(fastifyCookie);
+    expect(register.mock.calls[4][0]).toEqual(logging);
+    expect(register.mock.calls[5][0]).toEqual(fastifyMetrics);
+    expect(register.mock.calls[6]).toEqual([
       compress,
       {
         zlibOptions: {
@@ -137,30 +140,17 @@ describe('ssrServer', () => {
         encodings: ['gzip'],
       },
     ]);
-    expect(register.mock.calls[6][0]).toEqual(fastifyFormbody);
-    expect(register.mock.calls[7]).toEqual([
+    expect(register.mock.calls[7][0]).toEqual(fastifyFormbody);
+    expect(register.mock.calls[8]).toEqual([
       addSecurityHeadersPlugin,
       {
         matchGetRoutes: ['/_/status', '/_/pwa/service-worker.js', '/_/pwa/manifest.webmanifest'],
       },
     ]);
-    expect(register.mock.calls[8][0]).toEqual(setAppVersionHeader);
-    expect(register.mock.calls[9][0]).toEqual(forwardedHeaderParser);
-    expect(register.mock.calls[10][0]).toEqual(expect.any(Function)); // abstraction
+    expect(register.mock.calls[9][0]).toEqual(setAppVersionHeader);
+    expect(register.mock.calls[10][0]).toEqual(forwardedHeaderParser);
     expect(register.mock.calls[11][0]).toEqual(expect.any(Function)); // abstraction
-    expect(register.mock.calls[12][0]).toEqual(expect.any(Function)); // abstraction
-
-    const staticRegister = jest.fn();
-    register.mock.calls[10][0](
-      {
-        register: staticRegister,
-        get: jest.fn(),
-      },
-      null,
-      jest.fn()
-    );
-
-    expect(staticRegister.mock.calls[0]).toEqual([
+    expect(register.mock.calls[12]).toEqual([
       fastifyStatic,
       {
         root: path.join(__dirname, '../../build'),
@@ -168,35 +158,12 @@ describe('ssrServer', () => {
         maxAge: '182d',
       },
     ]);
-
-    const pwaRegister = jest.fn();
-    register.mock.calls[11][0](
-      {
-        register: pwaRegister,
-        get: jest.fn(),
-        post: jest.fn(),
-      },
-      null,
-      jest.fn()
-    );
-
-    expect(pwaRegister.mock.calls[0][0]).toEqual(addCacheHeaders);
-    expect(pwaRegister.mock.calls[1][0]).toEqual(csp);
-
-    const renderRegister = jest.fn();
-    register.mock.calls[12][0](
-      {
-        register: renderRegister,
-        get: jest.fn(),
-        post: jest.fn(),
-      },
-      null,
-      jest.fn()
-    );
-
-    expect(renderRegister.mock.calls[0][0]).toEqual(addCacheHeaders);
-    expect(renderRegister.mock.calls[1][0]).toEqual(csp);
-    expect(renderRegister.mock.calls[2]).toEqual([
+    expect(register.mock.calls[13][0]).toEqual(expect.any(Function)); // abstraction
+    expect(register.mock.calls[14][0]).toEqual(addCacheHeaders);
+    expect(register.mock.calls[15][0]).toEqual(csp);
+    expect(register.mock.calls[17][0]).toEqual(addCacheHeaders);
+    expect(register.mock.calls[18][0]).toEqual(csp);
+    expect(register.mock.calls[19]).toEqual([
       fastifyHelmet,
       {
         crossOriginEmbedderPolicy: false,
@@ -206,8 +173,8 @@ describe('ssrServer', () => {
         contentSecurityPolicy: false,
       },
     ]);
-    expect(renderRegister.mock.calls[3][0]).toEqual(addFrameOptionsHeader);
-    expect(renderRegister.mock.calls[4][0]).toEqual(renderHtml);
+    expect(register.mock.calls[20][0]).toEqual(addFrameOptionsHeader);
+    expect(register.mock.calls[21][0]).toEqual(renderHtml);
 
     expect(setNotFoundHandler).toHaveBeenCalledTimes(1);
     expect(setErrorHandler).toHaveBeenCalledTimes(1);
@@ -241,18 +208,6 @@ describe('ssrServer', () => {
   describe('static routes', () => {
     test('/_/status responds with 200', async () => {
       await ssrServer();
-
-      const get = jest.fn();
-
-      register.mock.calls[10][0](
-        {
-          register: jest.fn(),
-          get,
-        },
-        null,
-        jest.fn()
-      );
-
       const reply = {
         status: jest.fn(() => reply),
         send: jest.fn(() => reply),
@@ -268,17 +223,6 @@ describe('ssrServer', () => {
     test('/_/pwa/service-worker.js uses the serviceWorkerHandler handler', async () => {
       await ssrServer();
 
-      const get = jest.fn();
-
-      register.mock.calls[10][0](
-        {
-          register: jest.fn(),
-          get,
-        },
-        null,
-        jest.fn()
-      );
-
       const reply = {
         status: jest.fn(() => reply),
         send: jest.fn(() => reply),
@@ -293,43 +237,19 @@ describe('ssrServer', () => {
     test('/_/pwa/manifest.webmanifest uses the webManifestMiddleware handler', async () => {
       await ssrServer();
 
-      const get = jest.fn();
-
-      register.mock.calls[11][0](
-        {
-          register: jest.fn(),
-          get,
-          post: jest.fn(),
-        },
-        null,
-        jest.fn()
-      );
-
       const reply = {
         status: jest.fn(() => reply),
         send: jest.fn(() => reply),
       };
 
-      expect(get.mock.calls[0][0]).toEqual('/_/pwa/manifest.webmanifest');
-      expect(get.mock.calls[0][1]).toEqual(webManifestMiddleware);
+      expect(get.mock.calls[2][0]).toEqual('/_/pwa/manifest.webmanifest');
+      expect(get.mock.calls[2][1]).toEqual(webManifestMiddleware);
     });
 
     describe('DEVELOPMENT', () => {
       describe('empty body', () => {
         test('/_/report/security/csp-violation report with no data', async () => {
           await ssrServer();
-
-          const post = jest.fn();
-
-          register.mock.calls[11][0](
-            {
-              register: jest.fn(),
-              get: jest.fn(),
-              post,
-            },
-            null,
-            jest.fn()
-          );
 
           const request = {
             log: { warn: jest.fn() },
@@ -353,18 +273,6 @@ describe('ssrServer', () => {
       describe('missing csp-report', () => {
         test('/_/report/security/csp-violation report with no data', async () => {
           await ssrServer();
-
-          const post = jest.fn();
-
-          register.mock.calls[11][0](
-            {
-              register: jest.fn(),
-              get: jest.fn(),
-              post,
-            },
-            null,
-            jest.fn()
-          );
 
           const request = {
             headers: {
@@ -391,18 +299,6 @@ describe('ssrServer', () => {
 
       test('/_/report/security/csp-violation reports data', async () => {
         await ssrServer();
-
-        const post = jest.fn();
-
-        register.mock.calls[11][0](
-          {
-            register: jest.fn(),
-            get: jest.fn(),
-            post,
-          },
-          null,
-          jest.fn()
-        );
 
         const request = {
           body: JSON.stringify({
@@ -435,18 +331,6 @@ describe('ssrServer', () => {
       test('/_/report/errors responds with 204', async () => {
         await ssrServer();
 
-        const post = jest.fn();
-
-        register.mock.calls[11][0](
-          {
-            register: jest.fn(),
-            get: jest.fn(),
-            post,
-          },
-          null,
-          jest.fn()
-        );
-
         const request = {
           log: {
             warn: jest.fn(),
@@ -474,18 +358,6 @@ describe('ssrServer', () => {
           process.env.NODE_ENV = 'production';
           await ssrServer();
 
-          const post = jest.fn();
-
-          register.mock.calls[11][0](
-            {
-              register: jest.fn(),
-              get: jest.fn(),
-              post,
-            },
-            null,
-            jest.fn()
-          );
-
           const request = {
             headers: {},
             log: { warn: jest.fn() },
@@ -510,18 +382,6 @@ describe('ssrServer', () => {
         test('/_/report/security/csp-violation report with no data', async () => {
           process.env.NODE_ENV = 'production';
           await ssrServer();
-
-          const post = jest.fn();
-
-          register.mock.calls[11][0](
-            {
-              register: jest.fn(),
-              get: jest.fn(),
-              post,
-            },
-            null,
-            jest.fn()
-          );
 
           const request = {
             headers: {},
@@ -551,18 +411,6 @@ describe('ssrServer', () => {
 
         await ssrServer();
 
-        const post = jest.fn();
-
-        register.mock.calls[11][0](
-          {
-            register: jest.fn(),
-            get: jest.fn(),
-            post,
-          },
-          null,
-          jest.fn()
-        );
-
         const request = {
           headers: {
             'content-type': 'text/plain',
@@ -590,18 +438,6 @@ describe('ssrServer', () => {
         process.env.NODE_ENV = 'production';
 
         await ssrServer();
-
-        const post = jest.fn();
-
-        register.mock.calls[11][0](
-          {
-            register: jest.fn(),
-            get: jest.fn(),
-            post,
-          },
-          null,
-          jest.fn()
-        );
 
         const request = {
           headers: {
@@ -635,18 +471,6 @@ describe('ssrServer', () => {
         process.env.NODE_ENV = 'production';
 
         await ssrServer();
-
-        const post = jest.fn();
-
-        register.mock.calls[11][0](
-          {
-            register: jest.fn(),
-            get: jest.fn(),
-            post,
-          },
-          null,
-          jest.fn()
-        );
 
         const request = {
           headers: {
@@ -686,18 +510,6 @@ describe('ssrServer', () => {
         process.env.NODE_ENV = 'production';
 
         await ssrServer();
-
-        const post = jest.fn();
-
-        register.mock.calls[11][0](
-          {
-            register: jest.fn(),
-            get: jest.fn(),
-            post,
-          },
-          null,
-          jest.fn()
-        );
 
         const request = {
           headers: {
@@ -752,23 +564,13 @@ describe('ssrServer', () => {
 
         await ssrServer();
 
-        const get = jest.fn();
-        register.mock.calls[12][0](
-          {
-            register: jest.fn(),
-            get,
-          },
-          null,
-          jest.fn()
-        );
-
         const reply = {
           sendHtml: jest.fn(() => reply),
         };
 
-        get.mock.calls[0][1](null, reply);
+        get.mock.calls[3][1](null, reply);
 
-        expect(get.mock.calls[0][0]).toEqual('/_/pwa/shell');
+        expect(get.mock.calls[3][0]).toEqual('/_/pwa/shell');
         expect(reply.sendHtml).toHaveBeenCalled();
       });
 
@@ -779,24 +581,14 @@ describe('ssrServer', () => {
 
         await ssrServer();
 
-        const get = jest.fn();
-        register.mock.calls[12][0](
-          {
-            register: jest.fn(),
-            get,
-          },
-          null,
-          jest.fn()
-        );
-
         const reply = {
           status: jest.fn(() => reply),
           send: jest.fn(() => reply),
         };
 
-        get.mock.calls[0][1](null, reply);
+        get.mock.calls[3][1](null, reply);
 
-        expect(get.mock.calls[0][0]).toEqual('/_/pwa/shell');
+        expect(get.mock.calls[3][0]).toEqual('/_/pwa/shell');
         expect(reply.status).toHaveBeenCalledWith(404);
         expect(reply.send).toHaveBeenCalledWith('Not found');
       });
@@ -804,41 +596,22 @@ describe('ssrServer', () => {
       test('any other GET route renders html', async () => {
         await ssrServer();
 
-        const get = jest.fn();
-        register.mock.calls[12][0](
-          {
-            register: jest.fn(),
-            get,
-          },
-          null,
-          jest.fn()
-        );
-
         const reply = {
           sendHtml: jest.fn(() => reply),
         };
 
-        get.mock.calls[1][1](null, reply);
+        get.mock.calls[4][1](null, reply);
 
-        expect(get.mock.calls[1][0]).toEqual('/*');
+        expect(get.mock.calls[4][0]).toEqual('/*');
         expect(reply.sendHtml).toHaveBeenCalled();
       });
 
       test('any other POST route renders html is disabled', async () => {
         await ssrServer();
 
-        const post = jest.fn();
-        register.mock.calls[12][0](
-          {
-            register: jest.fn(),
-            get: jest.fn(),
-            post,
-          },
-          null,
-          jest.fn()
-        );
-
-        expect(post).not.toHaveBeenCalled();
+        expect(post).toHaveBeenCalledTimes(2);
+        expect(post.mock.calls[0][0]).toEqual('/_/report/security/csp-violation');
+        expect(post.mock.calls[1][0]).toEqual('/_/report/errors');
       });
 
       test('any other POST route renders html', async () => {
@@ -846,24 +619,14 @@ describe('ssrServer', () => {
 
         await ssrServer();
 
-        const post = jest.fn();
-        register.mock.calls[12][0](
-          {
-            register: jest.fn(),
-            get: jest.fn(),
-            post,
-          },
-          null,
-          jest.fn()
-        );
-
         const reply = {
           sendHtml: jest.fn(() => reply),
         };
 
-        post.mock.calls[0][1](null, reply);
+        post.mock.calls[2][1](null, reply);
 
-        expect(post.mock.calls[0][0]).toEqual('/*');
+        expect(post).toHaveBeenCalledTimes(3);
+        expect(post.mock.calls[2][0]).toEqual('/*');
         expect(reply.sendHtml).toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
## Description

Scopes the entire application within a top level plugin

## Motivation and Context

addresses fastify/fastify-cors#290

Currently rejected preflight requests result in an error because `preHandler` is called twice making it attempt to end timers that have already ended.

```
ERROR: Fastify application error: method OPTIONS, url "/success", correlationId "1fa8c448-db62-4552-968c-408857451b23", headersSent: false
    reqId: "req-1"
    error: {
      "type": "TypeError",
      "message": "The \"time\" argument must be an instance of Array. Received type number (9.911919)",
      "stack":
          TypeError [ERR_INVALID_ARG_TYPE]: The "time" argument must be an instance of Array. Received type number (9.911919)
              at process.hrtime (node:internal/process/per_thread:84:5)
              at endTimer (~/git/one-app-2/lib/server/utils/logging/fastifyPlugin.js:67:26)
              at Object.<anonymous> (~/git/one-app-2/lib/server/utils/logging/fastifyPlugin.js:189:5)
              at hookIterator (~/git/one-app-2/node_modules/fastify/lib/hooks.js:409:10)
              at next (~/git/one-app-2/node_modules/fastify/lib/hooks.js:243:18)
              at hookRunner (~/git/one-app-2/node_modules/fastify/lib/hooks.js:265:5)
              at notFound (~/git/one-app-2/node_modules/fastify/lib/reply.js:875:5)
              at Reply.callNotFound (~/git/one-app-2/node_modules/fastify/lib/reply.js:451:3)
              at Object.<anonymous> (~/git/one-app-2/node_modules/@fastify/cors/index.js:78:13)
              at preHandlerCallback (~/git/one-app-2/node_modules/fastify/lib/handleRequest.js:137:37)
      "code": "ERR_INVALID_ARG_TYPE"
    }
```

## How Has This Been Tested?

Ran the prod sample locally and sent the following request and validated the error no longer occurred:

```
$ curl --location --request OPTIONS 'http://localhost:3000/success' \
--header 'Origin: test.fail' \
--header 'Access-Control-Request-Method: GET' \
--header 'Access-Control-Request-Headers: content-type'
```

I also added logs to each of the handlers and tested the failing preflight before and after

**before**

Note that `preHandler` appears twice for `req-1`

```
WARN: onRequest 1
    reqId: "req-1"
WARN: onRequest 2
    reqId: "req-1"
WARN: preHandler
    reqId: "req-1"
WARN: preHandler
    reqId: "req-1"
ERROR: Fastify application error: method OPTIONS, url "/success", correlationId "1fa8c448-db62-4552-968c-408857451b23", headersSent: false
    reqId: "req-1"
    error: {
      "type": "TypeError",
      "message": "The \"time\" argument must be an instance of Array. Received type number (9.911919)",
      "stack":
          TypeError [ERR_INVALID_ARG_TYPE]: The "time" argument must be an instance of Array. Received type number (9.911919)
              at process.hrtime (node:internal/process/per_thread:84:5)
              at endTimer (/Users/jking48/git/one-app-2/lib/server/utils/logging/fastifyPlugin.js:67:26)
              at Object.<anonymous> (/Users/jking48/git/one-app-2/lib/server/utils/logging/fastifyPlugin.js:189:5)
              at hookIterator (/Users/jking48/git/one-app-2/node_modules/fastify/lib/hooks.js:409:10)
              at next (/Users/jking48/git/one-app-2/node_modules/fastify/lib/hooks.js:243:18)
              at hookRunner (/Users/jking48/git/one-app-2/node_modules/fastify/lib/hooks.js:265:5)
              at notFound (/Users/jking48/git/one-app-2/node_modules/fastify/lib/reply.js:875:5)
              at Reply.callNotFound (/Users/jking48/git/one-app-2/node_modules/fastify/lib/reply.js:451:3)
              at Object.<anonymous> (/Users/jking48/git/one-app-2/node_modules/@fastify/cors/index.js:78:13)
              at preHandlerCallback (/Users/jking48/git/one-app-2/node_modules/fastify/lib/handleRequest.js:137:37)
      "code": "ERR_INVALID_ARG_TYPE"
    }
WARN: onSend
    reqId: "req-1"
WARN: onResponse
    reqId: "req-1"
```

**after**

```
WARN: onRequest 1
    reqId: "req-1"
WARN: onRequest 2
    reqId: "req-1"
WARN: preHandler
    reqId: "req-1"
WARN: onSend
    reqId: "req-1"
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
No errors on preflight rejection