### PR TITLE
fix(errorHandler): application errors would result in a 200 response

### DIFF
--- a/__tests__/server/ssrServer.spec.js
+++ b/__tests__/server/ssrServer.spec.js
@@ -913,6 +913,7 @@ describe('ssrServer', () => {
         '"Fastify application error: method get, url "/example", correlationId "undefined", headersSent: false [Error: testing]"'
       );
       expect(renderStaticErrorPage).toHaveBeenCalledWith(request, reply);
+      expect(reply.code).toHaveBeenCalledWith(500);
     });
 
     test('setErrorHandler logs an error and renders the static error page with "headersSent" and "correlationId"', async () => {
@@ -946,6 +947,7 @@ describe('ssrServer', () => {
         '"Fastify application error: method get, url "/example", correlationId "123", headersSent: true [Error: testing]"'
       );
       expect(renderStaticErrorPage).toHaveBeenCalledWith(request, reply);
+      expect(reply.code).toHaveBeenCalledWith(500);
     });
   });
 });

--- a/src/server/ssrServer.js
+++ b/src/server/ssrServer.js
@@ -244,6 +244,7 @@ export async function createApp(opts = {}) {
 
     request.log.error('Fastify application error: method %s, url "%s", correlationId "%s", headersSent: %s', method, url, correlationId, headersSent, error);
 
+    reply.code(500);
     return renderStaticErrorPage(request, reply);
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set HTTP status code to 500 in application error handler

## Motivation and Context

Application errors were causing HTTP 200 responses

## How Has This Been Tested?

Triggered an application error caused by bug fixed in #1242 validated that HTTP status of error page was 200 before change and 500 after

> Note: integration tests will fail until #1242 is merged

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Correct HTTP status of application errors