### PR TITLE
fix(cdnCache): make clear cache message generic

### DIFF
--- a/__tests__/server/utils/cdnCache.spec.js
+++ b/__tests__/server/utils/cdnCache.spec.js
@@ -93,6 +93,18 @@ describe('cacheUtils', () => {
       expect(logSpy).not.toHaveBeenCalled();
       expect(errorSpy).toHaveBeenCalledWith('There was error checking file stat', expectedError);
     });
+
+    it('showCacheInfo should show file to delete', async () => {
+      const mockStats = {
+        size: 1024 * 1024 * 5, // 5 MB
+      };
+      fsPromises.stat.mockResolvedValue(mockStats);
+
+      await showCacheInfo();
+
+      expect(logSpy).toHaveBeenCalledWith('To clear the cache, please delete this file:');
+      expect(logSpy).toHaveBeenCalledWith('    ~/.one-app/.one-app-module-cache');
+    });
   });
 
   describe('setupCacheFile', () => {

--- a/src/server/utils/cdnCache.js
+++ b/src/server/utils/cdnCache.js
@@ -18,7 +18,6 @@ import chalk from 'chalk';
 
 export const getUserHomeDirectory = () => process.env.HOME || process.env.USERPROFILE;
 export const cacheFileName = '.one-app-module-cache';
-export const moduleCacheFileName = '.one-app-module-map-cache';
 export const oneAppDirectoryName = '.one-app';
 export const oneAppDirectoryPath = path.join(getUserHomeDirectory(), oneAppDirectoryName);
 export const oneAppModuleCachePath = path.join(oneAppDirectoryPath, cacheFileName);
@@ -33,8 +32,8 @@ export const showCacheInfo = async () => {
     console.log(chalk.bold.cyanBright(separator));
     console.log(chalk.bold.cyanBright('CACHE INFORMATION'));
     console.log(message);
-    console.log('To delete cache, please run');
-    console.log(`  ${chalk.bold.cyanBright('  rm ', oneAppModuleCachePath)}`);
+    console.log('To clear the cache, please delete this file:');
+    console.log(`    ${chalk.bold.cyanBright(path.join('~', oneAppDirectoryName, cacheFileName))}`);
     console.log(chalk.bold.cyanBright(separator));
   } catch (error) {
     console.error('There was error checking file stat', error);


### PR DESCRIPTION
## Description
Changes the message from:
```
LOG: **************************************************************
LOG: CACHE INFORMATION
LOG: File size of .one-app-module-cache: 1.00 MB
LOG: To delete cache, please run
LOG:     rm  /home/node/.one-app/.one-app-module-cache
LOG: **************************************************************
```
to:
```
LOG: **************************************************************
LOG: CACHE INFORMATION
LOG: File size of .one-app-module-cache: 1.00 MB
LOG: To clear the cache, please delete this file:
LOG:     ~/.one-app/.one-app-module-cache
LOG: **************************************************************
```

This is trying to be generic enough to work across Mac and Windows and standalone and Docker, but it's a difficult problem.

## Motivation and Context
Fixes #1244 

Namely, running `rm  /home/node/.one-app/.one-app-module-cache` will not delete the cache when running One App in Docker.

## How Has This Been Tested?
Added unit test.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
More accurate instructions.