### PR TITLE
chore(node): drop node 16

### DIFF
--- a/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
+++ b/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.x, 20.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
+++ b/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/guides/Publishing-Modules.md
+++ b/docs/guides/Publishing-Modules.md
@@ -123,10 +123,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v1
       with:
-        node-version: '16.x'
+        node-version: '18.x'
     - name: Cache NPM Dependencies
       uses: actions/cache@v1
       with:

--- a/docs/guides/Running-One-App-Locally.md
+++ b/docs/guides/Running-One-App-Locally.md
@@ -4,7 +4,7 @@
 
 # Running One App Locally
 
-To run One App locally, you need to make sure that you are on Node 16 or greater. After that, go ahead and clone One App:
+To run One App locally, you need to make sure that you are on Node 18. After that, go ahead and clone One App:
 
 ```bash
 git clone https://github.com/americanexpress/one-app.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,6 @@
         "https-proxy-agent": "^5.0.1",
         "husky": "^8.0.1",
         "if-env": "^1.0.4",
-        "if-node-version": "^1.1.1",
         "jest": "^29.6.4",
         "jest-circus": "^29.2.2",
         "jest-environment-jsdom": "^28.1.2",
@@ -134,7 +133,7 @@
         "webdriverio": "^7.34.0"
       },
       "engines": {
-        "node": ">=16 <=18",
+        "node": "^18",
         "npm": ">=8"
       }
     },
@@ -15499,91 +15498,6 @@
         "if-env": "bin/if-env.js"
       }
     },
-    "node_modules/if-node-version": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/if-node-version/-/if-node-version-1.1.1.tgz",
-      "integrity": "sha512-qMcJD7ftbSWlf+6w8nzZAWKOELmG3xH5Gu5XYW2+f9uaYj1t9JX5KNWxnvNMGhu8f+uIUgnqFHLlwyKTHaLWWA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^5.0.1",
-        "semver": "^5.2.0"
-      },
-      "bin": {
-        "if-node-version": "bin/index.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/if-node-version/node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/if-node-version/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/if-node-version/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/if-node-version/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/if-node-version/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/if-node-version/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/if-node-version/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "dev": true
-    },
     "node_modules/iferr": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
@@ -22146,12 +22060,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "One Amex SPA technology stack.",
   "main": "index.js",
   "engines": {
-    "node": ">=16 <=18",
+    "node": "^18",
     "npm": ">=8"
   },
   "scripts": {
@@ -13,9 +13,7 @@
     "clean:build": "rimraf dist lib build lastBuild.json stats.json",
     "clean:test": "rimraf test-results",
     "prebuild": "npm run clean:build",
-    "build:bundle": "if-node-version \">16\" && npm run build:bundle:gt-16  || npm run build:bundle:16",
-    "build:bundle:gt-16": "cross-env \"NODE_OPTIONS=--max-old-space-size=4096 --openssl-legacy-provider\" bundle-one-app",
-    "build:bundle:16": "cross-env NODE_OPTIONS=--max-old-space-size=4096 bundle-one-app",
+    "build:bundle": "cross-env \"NODE_OPTIONS=--max-old-space-size=4096 --openssl-legacy-provider\" bundle-one-app",
     "build:server": "cross-env BABEL_ENV=server babel src --out-dir lib --ignore \"**/__mocks__\"",
     "build:service-workers": "node scripts/build-service-workers.js",
     "build:artifacts:statics": "node scripts/build-static-assets-artifact.js",
@@ -178,7 +176,6 @@
     "https-proxy-agent": "^5.0.1",
     "husky": "^8.0.1",
     "if-env": "^1.0.4",
-    "if-node-version": "^1.1.1",
     "jest": "^29.6.4",
     "jest-circus": "^29.2.2",
     "jest-environment-jsdom": "^28.1.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "One Amex SPA technology stack.",
   "main": "index.js",
   "engines": {
-    "node": "^18",
+    "node": ">=18 <=20",
     "npm": ">=8"
   },
   "scripts": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Don't run tests on Node 16 or allow building on Node 16
- Run unit/lint tests on Node 20

## Motivation and Context

Node 16 has been EOL for quite some time now and we upgrade our image to Node 18 ages ago

The unit tests already pass on Node 20, so adding it to prevent regressions on that before we upgrade

## How Has This Been Tested?

`npm run build` (only the build script was affected)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
N/A