### PR TITLE
chore(vitruvius): update dep 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@americanexpress/one-app-bundler": "^6.21.1",
         "@americanexpress/one-app-ducks": "^4.4.2",
         "@americanexpress/one-app-router": "^1.2.1",
-        "@americanexpress/vitruvius": "^2.0.2",
+        "@americanexpress/vitruvius": "^3.0.1",
         "@fastify/compress": "^6.4.0",
         "@fastify/cookie": "^9.1.0",
         "@fastify/cors": "^8.4.0",
@@ -866,12 +866,12 @@
       }
     },
     "node_modules/@americanexpress/vitruvius": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@americanexpress/vitruvius/-/vitruvius-2.0.2.tgz",
-      "integrity": "sha512-OkFP1gPusPtI7W4swdmyuRX+f4APkN40YAddriNIguejicREZeGOaQkDsnFijSgBRLvXCQFsn5gz0ui4NIVJ3w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@americanexpress/vitruvius/-/vitruvius-3.0.1.tgz",
+      "integrity": "sha512-2jYK9UcigUDqoBbtB6oKYaXyaY0/xTke0B8QoPgBU7MoySXcf6sz85zYAGyQFu0qdEc6qiFiWn0Xg7gCPXcQyA==",
       "peerDependencies": {
         "immutable": "^3||^4.0.0-rc",
-        "redux": "^3||^4",
+        "redux": "^3||^4||^5",
         "redux-immutable": "^4.0.0"
       }
     },
@@ -15304,6 +15304,16 @@
       "peerDependencies": {
         "holocron": "^1.1.1",
         "react": ">=16.13.1"
+      }
+    },
+    "node_modules/holocron/node_modules/@americanexpress/vitruvius": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@americanexpress/vitruvius/-/vitruvius-2.0.2.tgz",
+      "integrity": "sha512-OkFP1gPusPtI7W4swdmyuRX+f4APkN40YAddriNIguejicREZeGOaQkDsnFijSgBRLvXCQFsn5gz0ui4NIVJ3w==",
+      "peerDependencies": {
+        "immutable": "^3||^4.0.0-rc",
+        "redux": "^3||^4",
+        "redux-immutable": "^4.0.0"
       }
     },
     "node_modules/holocron/node_modules/require-from-string": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@americanexpress/one-app-bundler": "^6.21.1",
     "@americanexpress/one-app-ducks": "^4.4.2",
     "@americanexpress/one-app-router": "^1.2.1",
-    "@americanexpress/vitruvius": "^2.0.2",
+    "@americanexpress/vitruvius": "^3.0.1",
     "@fastify/compress": "^6.4.0",
     "@fastify/cookie": "^9.1.0",
     "@fastify/cors": "^8.4.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Vitruvius drops support for node versions <18.
Includes support for redux 5 - non breaking.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
