### PR TITLE
feat(styles-loader): aggregate stylesheets and dedupe if already loaded

### DIFF
--- a/__tests__/server/utils/__snapshots__/renderModuleStyles.spec.js.snap
+++ b/__tests__/server/utils/__snapshots__/renderModuleStyles.spec.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renderModuleStyles should handle a mix of modules with and without SSR styles 1`] = `"<style class=\\"ssr-css\\">.test-module-b_class { color: red; }</style><style class=\\"ssr-css\\">.test-module-d_class { color: red; }</style>"`;
+exports[`renderModuleStyles should deduplicate aggregatedStyles that have the same digest hash 1`] = `"<style id=\\"shared_hash_deps\\" data-ssr=\\"true\\">.test-module-a_deps { color: blue; }</style><style id=\\"shared_hash_local\\" data-ssr=\\"true\\">.test-module-a_local { color: rebeccapurple; }</style><style id=\\"unique-hash_deps\\" data-ssr=\\"true\\">.test-module-c_deps { color: blue; }</style><style id=\\"unique-hash_local\\" data-ssr=\\"true\\">.test-module-c_local { color: rebeccapurple; }</style>"`;
+
+exports[`renderModuleStyles should handle a mix of modules with and without SSR styles 1`] = `"<style class=\\"ssr-css\\">.test-module-b_class { color: red; }</style><style class=\\"ssr-css\\">.test-module-d_class { color: red; }</style><style id=\\"test-module-e_deps\\" data-ssr=\\"true\\">.test-module-e_deps { color: blue; }</style><style id=\\"test-module-e_local\\" data-ssr=\\"true\\">.test-module-e_local { color: rebeccapurple; }</style>"`;
 
 exports[`renderModuleStyles should handle modules with SSR styles 1`] = `"<style class=\\"ssr-css\\">.test-module_class { color: red; }</style>"`;
 
-exports[`renderModuleStyles should not send empty styles 1`] = `"<style class=\\"ssr-css\\">.test-module-b_class { color: red; }</style>"`;
+exports[`renderModuleStyles should handle modules with aggregated SSR styles 1`] = `"<style id=\\"test-module_deps\\" data-ssr=\\"true\\">.test-module_deps { color: blue; }</style><style id=\\"test-module_local\\" data-ssr=\\"true\\">.test-module_local { color: rebeccapurple; }</style>"`;
+
+exports[`renderModuleStyles should not send empty styles 1`] = `"<style class=\\"ssr-css\\">.test-module-b_class { color: red; }</style><style id=\\"test-module-d_deps\\" data-ssr=\\"true\\">.test-module-d_deps { color: blue; }</style><style id=\\"test-module-d_local\\" data-ssr=\\"true\\">.test-module-d_local { color: rebeccapurple; }</style>"`;

--- a/src/server/utils/renderModuleStyles.js
+++ b/src/server/utils/renderModuleStyles.js
@@ -16,12 +16,62 @@
 
 import { getModule } from 'holocron';
 
+/**
+ * Generates a style tag with unique ID attribute per CSS file loaded.
+ * @returns {string}
+ */
+const generateStyleTag = ({ css, digest }) => `<style id="${digest}" data-ssr="true">${css}</style>`;
+
+const generateServerStyleTag = (css) => `<style class="ssr-css">${css}</style>`;
+
+const filterOutDuplicateDigests = (sheet, existingDigests) => sheet
+  .filter(({ css, digest }) => css && digest && !existingDigests.has(digest));
+
+const updateExistingDigests = (filteredSheets, existingDigests) => filteredSheets
+  .forEach((sheet) => { existingDigests.add(sheet.digest); });
+
 export default function renderModuleStyles(store) {
-  return store.getState().getIn(['holocron', 'loaded'], [])
+  const existingDigests = new Set();
+  const modulesWithSSRStyles = store.getState().getIn(['holocron', 'loaded'], [])
     .map((moduleName) => getModule(moduleName, store.modules))
-    .filter((module) => !!module.ssrStyles)
-    .map((module) => module.ssrStyles.getFullSheet())
+    .filter((module) => !!module.ssrStyles);
+
+  const collatedStyles = modulesWithSSRStyles
+    .reduce((acc, module) => {
+      // Backwards compatibility for older bundles.
+      if (!module.ssrStyles.aggregatedStyles) {
+        const ssrStylesFullSheet = module.ssrStyles.getFullSheet();
+        return {
+          ...acc,
+          legacy: ssrStylesFullSheet
+            ? [
+              ...acc.legacy,
+              { css: ssrStylesFullSheet },
+            ]
+            : acc.legacy,
+        };
+      }
+
+      const { aggregatedStyles } = module.ssrStyles;
+      const uniqueStyles = filterOutDuplicateDigests(aggregatedStyles, existingDigests);
+      updateExistingDigests(uniqueStyles, existingDigests);
+
+      return {
+        ...acc,
+        aggregated: [
+          ...acc.aggregated,
+          ...uniqueStyles,
+        ],
+      };
+    }, { aggregated: [], legacy: [] });
+
+  return [...collatedStyles.legacy, ...collatedStyles.aggregated]
     .filter(Boolean)
-    .map((ssrStylesFullSheet) => `<style class="ssr-css">${ssrStylesFullSheet}</style>`)
-    .join('');
+    .reduce((acc, { css, digest }) => {
+      if (!digest) {
+        return acc + generateServerStyleTag(css);
+      }
+
+      return acc + generateStyleTag({ css, digest });
+    }, '');
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change ports #1099 from one-app@6 to one-app@5. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is raised to support an existing one-app@6 feature in one-app@5. For the original motivation and context, please see the original PR (#1099). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
To test this change, I generated a root module and two child modules which all render on a single page. Within each module, I have installed a basic component library that imports a css module within the component:

```jsx
// Button.jsx
import styles from './styles.module.css';
// ...
<button {...otherProps} className={clsx(styles.button, className)}>
  {children}
</button>
```

```css
/* styles.module.css */
.button {
  background-color: blue;
  color: white;
  border: none;
  padding: 8px 16px;
}
```

Within each module, I've also created a `styles.module.css` with a class that changes the background color of the element it is applied to. This class has been applied to an instance of the `Button` component from the component library listed above with the text "With Changes".

> Note: the following pictures list the installed versions of one-app-bundler, but the relevant change is within the dev bundler. The installed version of the dev bundler (1.6.0 in root and child-a, 1.5.5 in child-b) in all cases includes the [relevant change needed to support this feature](https://github.com/americanexpress/one-app-cli/pull/557).

Before this change, the response from the server would look like this (note the duplicated button class and the lack of style overrides on the root and child-a):

![before-visual](https://github.com/americanexpress/one-app/assets/44091329/5566c7ba-b87c-4a13-8f4e-7d9d40ab045e)
![before-head](https://github.com/americanexpress/one-app/assets/44091329/55fb1dc4-140f-4c3b-b600-73dc3498f351)

After this change, the response from the server looks like this (note the single button class and the style overrides across all modules):

![after-visual](https://github.com/americanexpress/one-app/assets/44091329/187ba898-1d05-4816-94e2-e146d358018e)
![after-head](https://github.com/americanexpress/one-app/assets/44091329/5c5d2ebb-963b-422a-abdc-c33e51deaec1)


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
An existing feature on one-app@6 will be available to users still using one-app@5.