### PR TITLE
test(integration): use otel file exporter instead of logging exporter

### DIFF
--- a/.github/workflows/on-pr_one-app-integration-tests.yml
+++ b/.github/workflows/on-pr_one-app-integration-tests.yml
@@ -21,3 +21,11 @@ jobs:
         run: docker build -t one-app:at-test . --build-arg USER=root --build-arg VERSION=$(cat .nvmrc)
       - name: Run Integration Tests
         run: ONE_DANGEROUSLY_SKIP_ONE_APP_IMAGE_BUILD=true npm run test:integration
+      - name: Archive log & trace files
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: logs-and-traces
+          path: prod-sample/otel-collector/tmp/*.jsonl
+          overwrite: true
+          retention-days: 5

--- a/__tests__/integration/__snapshots__/one-app.spec.js.snap
+++ b/__tests__/integration/__snapshots__/one-app.spec.js.snap
@@ -94,4 +94,4 @@ exports[`Tests that require Docker setup one-app successfully started metrics ha
 
 exports[`Tests that require Docker setup one-app successfully started one-app server provides reporting routes client reported errors logs errors when reported to /_/report/errors 1`] = `"reported client error"`;
 
-exports[`Tests that require Docker setup one-app successfully started one-app server provides reporting routes csp-violations reported to server logs violations reported to /_/report/errors 1`] = `"CSP Violation: {"csp-report":{"document-uri":"bad.example.com"`;
+exports[`Tests that require Docker setup one-app successfully started one-app server provides reporting routes csp-violations reported to server logs violations reported to /_/report/errors 1`] = `"CSP Violation: {\\"csp-report\\":{\\"document-uri\\":\\"bad.example.com"`;

--- a/__tests__/integration/one-app.spec.js
+++ b/__tests__/integration/one-app.spec.js
@@ -809,7 +809,7 @@ describe('Tests that require Docker setup', () => {
           });
 
           test('fails to get external `react-intl` for child module as an unsupplied `requiredExternal` - Logs reverting message', async () => {
-            const revertErrorMatch = /There was an error loading module (?<moduleName>.*) at (?<url>.*). Reverting back to (?<workingModule>.*)/;
+            const revertErrorMatch = /There was an error loading module (?<moduleName>.*) at (?<url>.*). Reverting back to (?<workingModule>[^"]*)/;
             const requiredExternalsError = searchForNextLogMatch(revertErrorMatch);
             await addModuleToModuleMap({
               moduleName,
@@ -826,13 +826,8 @@ describe('Tests that require Docker setup', () => {
             const gitSha = await retrieveGitSha();
             await expect(requiredExternalsError).resolves.toMatch(revertErrorMatch);
             expect(problemModule).toBe('cultured-frankie');
-            expect(problemModuleUrl).toBe(
-              `${testCdnUrl}/${gitSha}/${moduleName}/${version}/${moduleName}.node.js`
-            );
-            // eslint-disable-next-line no-useless-escape
-            expect(workingUrl).toBe(
-              `${testCdnUrl}/${gitSha}/${moduleName}/0.0.0/${moduleName}.node.js)`
-            );
+            expect(problemModuleUrl).toBe(`${testCdnUrl}/${gitSha}/${moduleName}/${version}/${moduleName}.node.js`);
+            expect(workingUrl).toBe(`${testCdnUrl}/${gitSha}/${moduleName}/0.0.0/${moduleName}.node.js`);
           });
           test('fails to get external `semver` for child module as an unsupplied `requiredExternal` for new module in mooduleMap', async () => {
             const revertErrorMatch = /There was an error loading module (?<moduleName>.*) at (?<url>.*). Ignoring (?<ignoredModule>.*) until .*/;
@@ -2041,11 +2036,11 @@ describe('heapdump', () => {
 
     const aboutToWriteFilePath = aboutToWriteRaw
       .replace(/^about to write a heapdump to /, '')
-      .replace(/\).*$/, '');
+      .replace(/".+$/, '');
 
     const didWriteFilePath = didWriteRaw
       .replace(/^wrote heapdump out to /, '')
-      .replace(/\).*$/, '');
+      .replace(/".+$/, '');
 
     expect(aboutToWriteFilePath).toEqual(didWriteFilePath);
     expect(path.dirname(didWriteFilePath)).toBe('/tmp');

--- a/prod-sample/docker-compose.yml
+++ b/prod-sample/docker-compose.yml
@@ -106,10 +106,11 @@ services:
     # sleep 5s to make sure set up is completed prior to opening up chrome
     entrypoint: bash -c '/opt/bin/entry_point.sh & sleep 5s && chromium --ignore-certificate-errors --no-first-run --autofill-server-url https://one-app:8443/success'
   otel-collector:
-    image: 'otel/opentelemetry-collector:0.95.0'
+    image: 'otel/opentelemetry-collector-contrib-dev:9355dce6c04b89e76ef80e043709b5cc40c0de23'
     volumes:
       - ./otel-collector/config.yaml:/collector-config.yaml
       - ./otel-collector/tmp/traces.jsonl:/traces.jsonl
+      - ./otel-collector/tmp/logs.jsonl:/logs.jsonl
     command: ["--config=/collector-config.yaml"]
     ports:
       - "4317:4317"

--- a/prod-sample/otel-collector/config.yaml
+++ b/prod-sample/otel-collector/config.yaml
@@ -3,15 +3,17 @@ receivers:
     protocols:
       grpc:
 exporters:      
-  logging:
-    verbosity: detailed
-  file:
+  file/traces:
     path: ./traces.jsonl
+    append: true
+  file/logs:
+    path: ./logs.jsonl
+    append: true
 service:
   pipelines:
     logs:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [file/logs]
     traces:
       receivers: [otlp]
-      exporters: [file]
+      exporters: [file/traces]

--- a/scripts/build-one-app-docker-setup.js
+++ b/scripts/build-one-app-docker-setup.js
@@ -140,10 +140,13 @@ const doWork = async () => {
 
   // clear cdn of statics.
   await fs.emptyDir(nginxOriginStaticsAppDir);
-  const traceFilePath = path.resolve(sampleProdDir, 'otel-collector', 'tmp', 'traces.jsonl');
-  await fs.mkdir(path.dirname(traceFilePath), { recursive: true });
-  await fs.writeFile(traceFilePath, '');
-  await fs.chmod(traceFilePath, 0o666);
+
+  await Promise.all(['traces.jsonl', 'logs.jsonl'].map(async (file) => {
+    const filePath = path.resolve(sampleProdDir, 'otel-collector', 'tmp', file);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, '');
+    await fs.chmod(filePath, 0o666);
+  }));
 
   await handleCertGeneration({
     skipApiImagesBuild,


### PR DESCRIPTION
## Description

Use file exporter for logs in otel collector during integration tests & upload logs and traces as artifacts

## Motivation and Context

Better debuggability of integration tests on GH

## How Has This Been Tested?

This PR

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?

N/A