### PR TITLE
fix(server): devCDN should not crash when bundles are not present

### DIFF
--- a/__tests__/server/utils/__snapshots__/devCdnFactory.spec.js.snap
+++ b/__tests__/server/utils/__snapshots__/devCdnFactory.spec.js.snap
@@ -4,7 +4,49 @@ exports[`one-app-dev-cdn module-map.json extends the remote map with the local m
 
 exports[`one-app-dev-cdn module-map.json extends the remote map with the local map and uses host instead of localhost 1`] = `"{"key":"not-used-in-development","modules":{"module-b":{"node":{"url":"http://localhost:80/static/cdn/module-b/1.0.0/module-b.node.js","integrity":"123"},"browser":{"url":"http://localhost:80/static/cdn/module-b/1.0.0/module-b.browser.js","integrity":"234"},"legacyBrowser":{"url":"http://localhost:80/static/cdn/module-b/1.0.0/module-b.legacy.browser.js","integrity":"345"}},"module-a":{"node":{"url":"https://example.com/module-a/1.0.0/module-a.node.js","integrity":"123"},"browser":{"url":"https://example.com/module-a/1.0.0/module-a.browser.js","integrity":"234"},"legacyBrowser":{"url":"https://example.com/module-a/1.0.0/module-a.legacy.browser.js","integrity":"345"}}}}"`;
 
-exports[`one-app-dev-cdn module-map.json uses the local map overriding the cdn url placeholder with the one-app-dev-cdn url 1`] = `
+exports[`one-app-dev-cdn module-map.json replaces the CDN URL placeholder with the one-app-dev-cdn URL for bundle browser 1`] = `
+{
+  "key": "not-used-in-development",
+  "modules": {
+    "module-a": {
+      "browser": {
+        "integrity": "123",
+        "url": "http://localhost:3001/module-a/1.0.0/module-a.browser.js",
+      },
+    },
+  },
+}
+`;
+
+exports[`one-app-dev-cdn module-map.json replaces the CDN URL placeholder with the one-app-dev-cdn URL for bundle legacyBrowser 1`] = `
+{
+  "key": "not-used-in-development",
+  "modules": {
+    "module-a": {
+      "legacyBrowser": {
+        "integrity": "123",
+        "url": "http://localhost:3001/module-a/1.0.0/module-a.legacy.browser.js",
+      },
+    },
+  },
+}
+`;
+
+exports[`one-app-dev-cdn module-map.json replaces the CDN URL placeholder with the one-app-dev-cdn URL for bundle node 1`] = `
+{
+  "key": "not-used-in-development",
+  "modules": {
+    "module-a": {
+      "node": {
+        "integrity": "123",
+        "url": "http://localhost:3001/module-a/1.0.0/module-a.node.js",
+      },
+    },
+  },
+}
+`;
+
+exports[`one-app-dev-cdn module-map.json uses the local map overriding the CDN URL placeholder with the one-app-dev-cdn URL 1`] = `
 {
   "key": "not-used-in-development",
   "modules": {

--- a/src/server/utils/clientModuleMapCache.js
+++ b/src/server/utils/clientModuleMapCache.js
@@ -21,15 +21,19 @@ in ../server/middleware/sendHtml.js and reducing the html payload size */
 function filterBundles(moduleMap, moduleBundleType) {
   return {
     ...moduleMap,
-    modules: Object.entries(moduleMap.modules).reduce((acc, [moduleName, moduleBundles]) => (
-      {
+    modules: Object.entries(moduleMap.modules).reduce((acc, [moduleName, moduleBundles]) => {
+      if (!moduleBundles[moduleBundleType]) {
+        return acc;
+      }
+
+      return {
         ...acc,
         [moduleName]: {
           baseUrl: moduleBundles[moduleBundleType].url.replace(/[^/]+\.js$/i, ''),
           [moduleBundleType]: moduleBundles[moduleBundleType],
         },
-      }
-    ), {}),
+      };
+    }, {}),
   };
 }
 

--- a/src/server/utils/devCdnFactory.js
+++ b/src/server/utils/devCdnFactory.js
@@ -33,9 +33,15 @@ const getLocalModuleMap = ({ pathToModuleMap, oneAppDevCdnAddress }) => {
   const moduleMap = JSON.parse(fs.readFileSync(pathToModuleMap, 'utf8').toString());
   Object.keys(moduleMap.modules).forEach((moduleName) => {
     const module = moduleMap.modules[moduleName];
-    module.browser.url = module.browser.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
-    module.legacyBrowser.url = module.legacyBrowser.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
-    module.node.url = module.node.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
+    Object
+      .values(module)
+      .filter((bundle) => Object.hasOwnProperty.call(bundle, 'url'))
+      .forEach((bundle) => {
+        /* eslint-disable-next-line no-param-reassign -- the in-memory copy is created here during
+        // the read from disk, so the replacement side-effect of this loop is local to the
+        // getLocalModuleMap function and not to any arguments */
+        bundle.url = bundle.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
+      });
   });
   return JSON.stringify(moduleMap, null, 2);
 };

--- a/src/server/utils/devCdnFactory.js
+++ b/src/server/utils/devCdnFactory.js
@@ -78,15 +78,15 @@ const consumeRemoteRequest = async (remoteModuleMapUrl, hostAddress, remoteModul
       );
 
       // override remote module map to point all module URLs to one-app-dev-cdn
-      module.node.url = module.node.url.replace(
-        new URL(module.node.url).origin, oneAppDevStaticsAddress
-      );
-      module.legacyBrowser.url = module.legacyBrowser.url.replace(
-        new URL(module.legacyBrowser.url).origin, oneAppDevStaticsAddress
-      );
-      module.browser.url = module.browser.url.replace(
-        new URL(module.browser.url).origin, oneAppDevStaticsAddress
-      );
+      Object
+        .values(module)
+        .filter((bundle) => Object.hasOwnProperty.call(bundle, 'url'))
+        .forEach((bundle) => {
+          /* eslint-disable-next-line no-param-reassign -- the in-memory copy is created here during
+          // the read from network, so the replacement side-effect of this loop is local to the
+          // consumeRemoteRequest function and not to any arguments */
+          bundle.url = bundle.url.replace(new URL(bundle.url).origin, oneAppDevStaticsAddress);
+        });
       return module;
     });
     return remoteModuleMap;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The development CDN crashes when performing the substitution in the URL of a nonexistant bundle.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The legacy browser bundle is optional, not required.

```
err: {
    "type": "TypeError",
    "message": "Cannot read properties of undefined (reading 'url')",
    "stack":
        TypeError: Cannot read properties of undefined (reading 'url')
            at .../one-app/lib/server/utils/devCdnFactory.js:44:53
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests added that have only one bundle each.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Resolve the server crashing on them when running with modules that have not opted in to building the legacy browser bundles.