### PR TITLE
fix(serve-module): dev cdn would fail to start when serving modules without a legacy bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@americanexpress/fetch-enhancers": "^1.1.5",
         "@americanexpress/one-app-ducks": "^4.5.1",
         "@americanexpress/one-app-router": "^1.2.1",
-        "@americanexpress/one-app-server-bundler": "^1.0.2",
+        "@americanexpress/one-app-server-bundler": "^1.0.3",
         "@americanexpress/vitruvius": "^3.0.1",
         "@autotelic/fastify-opentelemetry": "^0.20.0",
         "@fastify/compress": "^7.0.0",
@@ -343,9 +343,9 @@
       }
     },
     "node_modules/@americanexpress/one-app-server-bundler": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@americanexpress/one-app-server-bundler/-/one-app-server-bundler-1.0.2.tgz",
-      "integrity": "sha512-vI622yT85ILLcGTWoAHn4DAV2cVsWajlzxmB44wLHTof83oFQFDFF1lmUTKjFHkmOzknEG8oFmzoXb/Kr1vVSQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@americanexpress/one-app-server-bundler/-/one-app-server-bundler-1.0.3.tgz",
+      "integrity": "sha512-ZHaKe8mf1euO1rGc82tyuWKjtQB4UgxzZE29PtF4AzndavP/YPrY8U67TIOoUyVyoHJ4JIHnBNqjKAugKtiHPw==",
       "dependencies": {
         "babel-loader": "^8.3.0",
         "babel-preset-amex": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@americanexpress/fetch-enhancers": "^1.1.5",
     "@americanexpress/one-app-ducks": "^4.5.1",
     "@americanexpress/one-app-router": "^1.2.1",
-    "@americanexpress/one-app-server-bundler": "^1.0.2",
+    "@americanexpress/one-app-server-bundler": "^1.0.3",
     "@americanexpress/vitruvius": "^3.0.1",
     "@autotelic/fastify-opentelemetry": "^0.20.0",
     "@fastify/compress": "^7.0.0",


### PR DESCRIPTION
## Description

Update  @americanexpress/one-app-server-bundler to 1.0.3

## Motivation and Context

See americanexpress/one-app-cli#629

## How Has This Been Tested?

Validated manually by @code-forger

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [x] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?

Will be able to serve modules without legacy bundle