### PR TITLE
test(integration): only send logs to stdout on debug runs

### DIFF
--- a/__tests__/integration/helpers/testRunner.js
+++ b/__tests__/integration/helpers/testRunner.js
@@ -94,8 +94,9 @@ const setUpTestRunner = async ({
     logWatcherDuplex.on('close', () => tail.kill());
   }));
 
-  // uncomment this line in order to view full logs for debugging
-  logWatcherDuplex.pipe(process.stdout);
+  if (process.env.RUNNER_DEBUG) {
+    logWatcherDuplex.pipe(process.stdout);
+  }
 
   try {
     await Promise.all([


### PR DESCRIPTION
## Description

Only send logs from integration tests to stdout on runner debug

https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables

## Motivation and Context

When tests are passing, this is just noise. Logs are available as file artifact either way

## How Has This Been Tested?

This PR. 

- [attempt #1](https://github.com/americanexpress/one-app/actions/runs/8512209359/job/23313361372?pr=1351) no logs in stdout
- [attempt #2](https://github.com/americanexpress/one-app/actions/runs/8512209359/job/23313793977?pr=1351) with debug checkbox checked, logs in stdout

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?

N/A