### PR TITLE
Fix: watch local modules other bundles, 5.x.x

### DIFF
--- a/__tests__/server/utils/watchLocalModules.spec.js
+++ b/__tests__/server/utils/watchLocalModules.spec.js
@@ -14,6 +14,7 @@
  * permissions and limitations under the License.
  */
 
+import fs from 'fs';
 import path from 'path';
 import { fromJS } from 'immutable';
 import chokidar from 'chokidar';
@@ -21,15 +22,272 @@ import loadModule from 'holocron/loadModule.node';
 import { getModules, resetModuleRegistry } from 'holocron/moduleRegistry';
 import watchLocalModules from '../../../src/server/utils/watchLocalModules';
 
-jest.mock('chokidar', () => {
-  const listeners = {};
-  const watcher = () => null;
-  watcher.on = (event, listener) => {
-    listeners[event] = listener;
+const setTimeoutNative = global.setTimeout;
+const sleep = (ms) => new Promise((resolve) => setTimeoutNative(resolve, ms));
+jest.useFakeTimers();
+
+jest.mock('fs', () => {
+  const fs = jest.requireActual('fs');
+
+  let mockedFilesystem;
+  /* Map {
+    indicator: 'd',
+    stat: {...},
+    entries: Map {
+      'home': Map {
+        indicator: 'd',
+        stat: {...},
+        entries: Map {
+          'username': Map {
+            indicator: 'd',
+            stat: {...},
+            entries: Map {
+              'hello.txt': Map {
+                indicator: 'f',
+                stat: {...},
+              }
+            }
+          }
+        }
+      }
+    }
+  } */
+
+  function getEntry(parts) {
+    let current = mockedFilesystem;
+    for (let i = 0; i < parts.length; i++) {
+      if (!current || !current.has('entries')) {
+        return null;
+      }
+      const entryName = parts[i];
+      current = current.get('entries').get(entryName);
+    }
+
+    return current;
+  }
+
+  let inodeCount = 0;
+  const mock = {
+    clear() {
+      const createdMillis = Date.now() + Math.floor(Math.random() * 1e4) / 1e4;
+      mockedFilesystem = new Map([
+        ['indicator', 'd'],
+        [
+          'stat',
+          {
+            dev: 1234,
+            mode: 16877,
+            nlink: 1,
+            uid: 512,
+            gid: 512,
+            rdev: 0,
+            blksize: 4096,
+            ino: ++inodeCount,
+            size: 128,
+            blocks: 0,
+            atimeMs: Date.now() + Math.floor(Math.random() * 1e4) / 1e4,
+            mtimeMs: createdMillis,
+            ctimeMs: createdMillis,
+            birthtimeMs: createdMillis,
+          },
+        ],
+        ['entries', new Map()],
+      ]);
+    },
+    delete(fsPath) {
+      const parts = fsPath.split('/').filter(Boolean);
+      const final = parts.pop();
+      const parent = getEntry(parts);
+      if (!parent || !parent.has('entries')) {
+        throw new Error(`not in mock fs ${fsPath} (delete)`);
+      }
+      parent.get('entries').delete(final);
+      return mock;
+    },
+    mkdir(fsPath, { parents: createParents } = { parents: false }) {
+      let parent = mockedFilesystem;
+      const parts = fsPath.split('/').filter(Boolean);
+
+      for (let i = 0; i < parts.length; i++) {
+        const nextEntry = parts[i];
+        if (
+          parent.get('entries').has(nextEntry) &&
+          parent.get('entries').get(nextEntry).get('indicator') !== 'd'
+        ) {
+          throw new Error(`parent is not a directory ${fsPath} (mkdir)`);
+        }
+        if (!parent.get('entries').has(nextEntry)) {
+          if (i !== (parts.length - 1) && !createParents) {
+            throw new Error(`parent directory does not exist for ${fsPath}`);
+          }
+          parent.get('entries').set(
+            nextEntry,
+            new Map([
+              ['indicator', 'd'],
+              [
+                'stat',
+                {
+                  dev: 1234,
+                  mode: 16877,
+                  nlink: 1,
+                  uid: 512,
+                  gid: 512,
+                  rdev: 0,
+                  blksize: 4096,
+                  ino: ++inodeCount,
+                  size: 128,
+                  blocks: 0,
+                  atimeMs: Date.now() + 0.3254,
+                  mtimeMs: Date.now() + 0.2454,
+                  ctimeMs: Date.now() + 0.2454,
+                  birthtimeMs: Date.now() + 0.0117,
+                },
+              ],
+              ['entries', new Map()],
+            ])
+          );
+        }
+        parent = parent.get('entries').get(nextEntry);
+      }
+      return mock;
+    },
+    writeFile(fsPath, contents) {
+      const parts = fsPath.split('/').filter(Boolean);
+      const final = parts.pop();
+      const parent = getEntry(parts);
+      if (!parent || !parent.get('entries')) {
+        throw new Error(`not in mock fs ${fsPath} (write)`);
+      }
+
+      if (parent.get('entries').has(final)) {
+        const fileEntry = parent.get('entries').get(final);
+        Object.assign(
+          fileEntry.get('stat'),
+          { mtimeMs: Date.now() + Math.floor(Math.random() * 1e4) / 1e4 }
+        );
+        fileEntry.set('contents', contents);
+      } else {
+        const createdMillis = Date.now() + Math.floor(Math.random() * 1e4) / 1e4;
+        parent.get('entries').set(
+          final,
+          new Map([
+            ['indicator', 'f'],
+            [
+              'stat',
+              {
+                dev: 1234,
+                mode: 33188,
+                nlink: 1,
+                uid: 512,
+                gid: 512,
+                rdev: 0,
+                blksize: 4096,
+                ino: ++inodeCount,
+                size: contents.length,
+                blocks: contents.length / 512,
+                atimeMs: Date.now() + Math.floor(Math.random() * 1e4) / 1e4,
+                mtimeMs: createdMillis,
+                ctimeMs: createdMillis,
+                birthtimeMs: createdMillis,
+              },
+            ],
+            ['contents', contents],
+          ])
+        );
+      }
+
+      return mock;
+    },
+    print() {
+      function traverser(parentPath, entry) {
+        let printout = '';
+        for (const [childName, childNode] of entry.get('entries').entries()) {
+          const childPath = `${parentPath}/${childName}`;
+          if (!childNode) {
+            throw new Error(`no child for ${childName}??`);
+          }
+          const indicator = childNode.get('indicator');
+          printout += `${indicator} ${childPath}\n`;
+          if (indicator === 'd') {
+            printout += traverser(childPath, childNode);
+          }
+        }
+        return printout;
+      }
+
+      const printout = traverser('', mockedFilesystem);
+      console.log(printout);
+      return mock;
+    },
   };
-  const watch = jest.fn(() => watcher);
-  const getListeners = () => listeners;
-  return { watch, getListeners };
+
+  mock.clear();
+
+  jest.spyOn(fs, 'readdir').mockImplementation((dirPath, callback) => {
+    const parts = dirPath.split('/').filter(Boolean);
+    const dir = getEntry(parts);
+    if (!dir) {
+      setImmediate(callback, new Error(`not in mock fs ${dirPath} (readdir)`));
+      return;
+    }
+    if (dir.get('indicator') !== 'd') {
+      setImmediate(callback, new Error(`not a mocked directory ${dirPath} (readdir)`));
+      return;
+    }
+
+    setImmediate(callback, null, [...dir.get('entries').keys()]);
+    return;
+  });
+
+  jest.spyOn(fs.promises, 'stat').mockImplementation(
+    (fsPath) =>
+      new Promise((resolve, reject) => {
+        const entry = getEntry(fsPath.split('/').filter(Boolean));
+        if (!entry) {
+          return reject(new Error(`no entry for ${fsPath} (stat)`));
+        }
+
+        const statArgs = entry.get('stat');
+        const {
+          dev,
+          mode,
+          nlink,
+          uid,
+          gid,
+          rdev,
+          blksize,
+          ino,
+          size,
+          blocks,
+          atimeMs,
+          mtimeMs,
+          ctimeMs,
+          birthtimeMs,
+        } = statArgs;
+        return resolve(
+          new fs.Stats(
+            dev,
+            mode,
+            nlink,
+            uid,
+            gid,
+            rdev,
+            blksize,
+            ino,
+            size,
+            blocks,
+            atimeMs,
+            mtimeMs,
+            ctimeMs,
+            birthtimeMs
+          )
+        );
+      })
+  );
+
+  fs.mock = mock;
+
+  return fs;
 });
 
 jest.mock('holocron/moduleRegistry', () => {
@@ -65,31 +323,17 @@ describe('watchLocalModules', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     delete process.env.HTTP_ONE_APP_DEV_CDN_PORT;
+    fs.mock.clear();
+  });
+  afterEach(() => {
+    jest.clearAllTimers();
   });
   afterAll(() => {
     process.env.HTTP_ONE_APP_DEV_CDN_PORT = origOneAppDevCDNPort;
   });
 
-  it('should watch the modules directory', () => {
-    watchLocalModules();
-    expect(chokidar.watch).toHaveBeenCalledTimes(1);
-    expect(chokidar.watch.mock.calls[0][0]).toMatchInlineSnapshot('"*/*/*.node.js"');
-    // absolute path varies based on where the repository has been checked out
-    expect(chokidar.watch.mock.calls[0][1]).toHaveProperty('cwd');
-    const { cwd } = chokidar.watch.mock.calls[0][1];
-    delete chokidar.watch.mock.calls[0][1].cwd;
-    expect(path.relative(path.resolve(__dirname, '../../../'), cwd)).toMatchInlineSnapshot(
-      '"static/modules"'
-    );
-    // can now look at the rest
-    expect(chokidar.watch.mock.calls[0][1]).toMatchInlineSnapshot(`
-      Object {
-        "awaitWriteFinish": true,
-      }
-    `);
-  });
-
   it('should tell the user when a module build was updated', async () => {
+    expect.assertions(6);
     const moduleName = 'some-module';
     const moduleVersion = '1.0.1';
     const moduleMapSample = {
@@ -111,26 +355,54 @@ describe('watchLocalModules', () => {
         },
       },
     };
-    const modulePath = `${moduleName}/${moduleVersion}/${moduleName}.node.js`;
     const originalModule = () => null;
     const updatedModule = () => null;
     const modules = fromJS({ [moduleName]: originalModule });
     const moduleMap = fromJS(moduleMapSample);
     resetModuleRegistry(modules, moduleMap);
+    fs.mock
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+
     watchLocalModules();
-    const changeListener = chokidar.getListeners().change;
+
     expect(getModules().get(moduleName)).toBe(originalModule);
     loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
-    await changeListener(modulePath);
-    expect(console.log).toHaveBeenCalled();
+    jest.runOnlyPendingTimers();
+    await sleep(100);
+    expect(console.log).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30e3);
+    fs.mock
+      .delete(path.resolve('static/modules', moduleName))
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+    
+    expect(console.log).toHaveBeenCalledTimes(1);
     expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "the Node.js bundle for some-module finished saving, attempting to load",
       ]
     `);
+
+    await sleep(500);
+
+    expect(console.log).toHaveBeenCalledTimes(2);
+    expect(console.log.mock.calls[1]).toMatchInlineSnapshot(`
+      Array [
+        "finished reloading some-module",
+      ]
+    `);
   });
 
   it('should tell the user when the updated module is loaded', async () => {
+    expect.assertions(6);
     const moduleName = 'some-module';
     const moduleVersion = '1.0.1';
     const moduleMapSample = {
@@ -158,11 +430,32 @@ describe('watchLocalModules', () => {
     const modules = fromJS({ [moduleName]: originalModule });
     const moduleMap = fromJS(moduleMapSample);
     resetModuleRegistry(modules, moduleMap);
+    fs.mock
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+
     watchLocalModules();
-    const changeListener = chokidar.getListeners().change;
+
     expect(getModules().get(moduleName)).toBe(originalModule);
     loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
-    await changeListener(modulePath);
+    jest.runOnlyPendingTimers();
+    await sleep(100);
+    expect(console.log).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30e3);
+    fs.mock
+      .delete(path.resolve('static/modules', moduleName))
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
+
     expect(loadModule).toHaveBeenCalledTimes(1);
     expect(getModules().get(moduleName)).toBe(updatedModule);
     expect(console.log).toHaveBeenCalledTimes(2);
@@ -174,6 +467,7 @@ describe('watchLocalModules', () => {
   });
 
   it('should update the module registry when a server bundle changes', async () => {
+    expect.assertions(7);
     const moduleName = 'some-module';
     const moduleVersion = '1.0.1';
     const moduleMapSample = {
@@ -201,11 +495,32 @@ describe('watchLocalModules', () => {
     const modules = fromJS({ [moduleName]: originalModule });
     const moduleMap = fromJS(moduleMapSample);
     resetModuleRegistry(modules, moduleMap);
+    fs.mock
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+
     watchLocalModules();
-    const changeListener = chokidar.getListeners().change;
     expect(getModules().get(moduleName)).toBe(originalModule);
     loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
-    await changeListener(modulePath);
+
+    jest.runOnlyPendingTimers();
+    await sleep(100);
+    expect(console.log).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30e3);
+    fs.mock
+      .delete(path.resolve('static/modules', moduleName))
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
+
     expect(loadModule).toHaveBeenCalledTimes(1);
     expect(loadModule.mock.calls[0][0]).toBe(moduleName);
     expect(loadModule.mock.calls[0][1]).toMatchInlineSnapshot(`
@@ -232,6 +547,7 @@ describe('watchLocalModules', () => {
   });
 
   it('should not change the module registry when a new module fails to load', async () => {
+    expect.assertions(4);
     const moduleName = 'some-module';
     const moduleVersion = '1.0.1';
     const moduleMapSample = {
@@ -258,64 +574,313 @@ describe('watchLocalModules', () => {
     const modules = fromJS({ [moduleName]: originalModule });
     const moduleMap = fromJS(moduleMapSample);
     resetModuleRegistry(modules, moduleMap);
-    watchLocalModules();
-    const changeListener = chokidar.getListeners().change;
-    expect(getModules().get(moduleName)).toBe(originalModule);
-    loadModule.mockImplementationOnce(() => Promise.reject(new Error('sample-module startup error')));
+    fs.mock
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
 
-    // usually we'd expect the thrown error to propogate up but loadModule take it upon itself to
-    // log the error for the user, so watchLocalModules avoids logging the error another time, and
-    // avoids throwing the error as that would log the error a _third_ time
-    // so instead of rejecting here `await expect(changeListener(modulePath)).rejects.toThrow(...)`
-    // we look to the resolution
-    await expect(changeListener(modulePath)).resolves.toBe(undefined);
+    watchLocalModules();
+    expect(getModules().get(moduleName)).toBe(originalModule);
+    loadModule.mockImplementationOnce(() =>
+      Promise.reject(new Error('sample-module startup error'))
+    );
+
+    jest.runOnlyPendingTimers();
+    await sleep(100);
+    expect(console.log).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30e3);
+    fs.mock
+      .delete(path.resolve('static/modules', moduleName))
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
 
     expect(loadModule).toHaveBeenCalledTimes(1);
     expect(getModules().get(moduleName)).toBe(originalModule);
   });
 
-  it('should warn the user about what looks like a changed module that cannot be used', async () => {
-    const changedPath = 'dont-match-me.node.js';
+  it('should wait if the file was written to since it was detected to have changed', async () => {
+    expect.assertions(5);
+    const moduleName = 'some-module';
+    const moduleVersion = '1.0.1';
+    const moduleMapSample = {
+      modules: {
+        [moduleName]: {
+          baseUrl: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/`,
+          node: {
+            integrity: '133',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.node.js`,
+          },
+          browser: {
+            integrity: '234',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.browser.js`,
+          },
+          legacyBrowser: {
+            integrity: '134633',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.legacy.browser.js`,
+          },
+        },
+      },
+    };
+    const originalModule = () => null;
+    const updatedModule = () => null;
+    const modules = fromJS({ [moduleName]: originalModule });
+    const moduleMap = fromJS(moduleMapSample);
+    resetModuleRegistry(modules, moduleMap);
+    fs.mock
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+
     watchLocalModules();
-    const changeListener = chokidar.getListeners().change;
-    await changeListener(changedPath);
-    expect(loadModule).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.warn.mock.calls[0]).toMatchInlineSnapshot(`
+
+    expect(getModules().get(moduleName)).toBe(originalModule);
+    loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
+    jest.runOnlyPendingTimers();
+    await sleep(100);
+    expect(console.log).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30e3);
+    fs.mock
+      .delete(path.resolve('static/modules', moduleName))
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("he')
+      
+    jest.advanceTimersByTime(300);
+    await sleep(5);
+    
+    expect(console.log).not.toHaveBeenCalled();
+    
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
-        "detected a change in module static resources at \\"dont-match-me.node.js\\" but unable to reload it in the running server",
+        "the Node.js bundle for some-module finished saving, attempting to load",
       ]
     `);
   });
+  
+  it.todo('should load a module that has since been built but was not on disk when the process started');
+  
+  it.todo('should ignore modules that are not in the module map');
+  
+  // instance when the CHANGE_WATCHER_INTERVAL and WRITING_FINISH_WATCHER_TIMEOUT lined up
+  // we need to avoid scheduling the write watcher like a tree (many branches, eventually eating all CPU and memory)
+  it.todo('should schedule watching for writes only once when both watchers have run');
 
   it('should ignore changes to all bundles but the server bundle', async () => {
+    expect.assertions(3);
     const moduleName = 'some-module';
     const moduleVersion = '1.0.0';
+    const moduleMapSample = {
+      modules: {
+        [moduleName]: {
+          baseUrl: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/`,
+          node: {
+            integrity: '133',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.node.js`,
+          },
+          browser: {
+            integrity: '234',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.browser.js`,
+          },
+          legacyBrowser: {
+            integrity: '134633',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.legacy.browser.js`,
+          },
+        },
+      },
+    };
+    const originalModule = () => null;
+    const updatedModule = () => null;
+    const modules = fromJS({ [moduleName]: originalModule });
+    const moduleMap = fromJS(moduleMapSample);
+    resetModuleRegistry(modules, moduleMap);
+    fs.mock
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello Node.js");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.browser.js`), 'console.log("hello Browser");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.legacy.browser.js`), 'console.log("hello previous spec Browser");');
+
     watchLocalModules();
-    const changeListener = chokidar.getListeners().change;
-    await changeListener(`${moduleName}/${moduleVersion}/${moduleName}.browser.js`);
+    
+    jest.runOnlyPendingTimers();
+    await sleep(100);
+    expect(console.log).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30e3);
+    fs.mock
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.browser.js`), 'console.log("hello again Browser");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.legacy.browser.js`), 'console.log("hello again previous spec Browser");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
+
     expect(loadModule).not.toHaveBeenCalled();
-    await changeListener(`${moduleName}/${moduleVersion}/${moduleName}.legacy.browser.js`);
-    expect(loadModule).not.toHaveBeenCalled();
+
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello Node.js");')
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
+
+    expect(loadModule).toHaveBeenCalled();
   });
 
   it('should ignore changes to server bundles that are not the module entrypoint', async () => {
+    expect.assertions(3);
     const moduleName = 'some-module';
     const moduleVersion = '1.0.0';
-    const changedPath = `${moduleName}/${moduleVersion}/vendors.node.js`;
+    const moduleMapSample = {
+      modules: {
+        [moduleName]: {
+          baseUrl: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/`,
+          node: {
+            integrity: '133',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.node.js`,
+          },
+          browser: {
+            integrity: '234',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.browser.js`,
+          },
+          legacyBrowser: {
+            integrity: '134633',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.legacy.browser.js`,
+          },
+        },
+      },
+    };
+    const modulePath = `${moduleName}/${moduleVersion}/${moduleName}.node.js`;
+    const originalModule = () => null;
+    const updatedModule = () => null;
+    const modules = fromJS({ [moduleName]: originalModule });
+    const moduleMap = fromJS(moduleMapSample);
+    resetModuleRegistry(modules, moduleMap);
+    fs.mock
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `vendors.node.js`), 'console.log("hi");');
+      
     watchLocalModules();
-    const changeListener = chokidar.getListeners().change;
-    await changeListener(changedPath);
+    
+    jest.runOnlyPendingTimers();
+    await sleep(100);
+    expect(console.log).not.toHaveBeenCalled();
+    
+    jest.advanceTimersByTime(30e3);
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `vendors.node.js`), 'console.log("hi there");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
     expect(loadModule).not.toHaveBeenCalled();
+
+    
+    fs.mock
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
+
+    expect(loadModule).toHaveBeenCalled();
   });
 
   it('should ignore changes to files that are not JavaScript', async () => {
+    expect.assertions(3);
     const moduleName = 'some-module';
     const moduleVersion = '1.0.0';
-    const changedPath = `${moduleName}/${moduleVersion}/assets/image.png`;
+    const moduleMapSample = {
+      modules: {
+        [moduleName]: {
+          baseUrl: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/`,
+          node: {
+            integrity: '133',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.node.js`,
+          },
+          browser: {
+            integrity: '234',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.browser.js`,
+          },
+          legacyBrowser: {
+            integrity: '134633',
+            url: `http://localhost:3001/static/modules/${moduleName}/${moduleVersion}/${moduleName}.legacy.browser.js`,
+          },
+        },
+      },
+    };
+    const modulePath = `${moduleName}/${moduleVersion}/${moduleName}.node.js`;
+    const originalModule = () => null;
+    const updatedModule = () => null;
+    const modules = fromJS({ [moduleName]: originalModule });
+    const moduleMap = fromJS(moduleMapSample);
+    resetModuleRegistry(modules, moduleMap);
+    fs.mock
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");')
+      .mkdir(path.resolve('static/modules', moduleName, moduleVersion, 'assets'), { parents: true })
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, 'assets', `image.png`), 'binary stuff');
+
     watchLocalModules();
-    const changeListener = chokidar.getListeners().change;
-    await changeListener(changedPath);
+
+    jest.runOnlyPendingTimers();
+    await sleep(100);
+    expect(console.log).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(30e3);
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, 'assets', `image.png`), 'other binary stuff');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
     expect(loadModule).not.toHaveBeenCalled();
+
+
+    fs.mock
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.runOnlyPendingTimers();
+    await sleep(5);
+    jest.advanceTimersByTime(100);
+
+    await sleep(500);
+
+    expect(loadModule).toHaveBeenCalled();
   });
 });

--- a/__tests__/server/utils/watchLocalModules.spec.js
+++ b/__tests__/server/utils/watchLocalModules.spec.js
@@ -422,7 +422,8 @@ describe('watchLocalModules', () => {
     expect(console.info).toHaveBeenCalledTimes(2);
     expect(console.info.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
-        "the Node.js bundle for some-module finished saving, attempting to load",
+        "the Node.js bundle for %s finished saving, attempting to load",
+        "some-module",
       ]
     `);
   });
@@ -516,7 +517,8 @@ describe('watchLocalModules', () => {
     expect(console.info).toHaveBeenCalledTimes(2);
     expect(console.info.mock.calls[1]).toMatchInlineSnapshot(`
       Array [
-        "finished reloading some-module",
+        "finished reloading %s",
+        "some-module",
       ]
     `);
   });
@@ -902,7 +904,8 @@ describe('watchLocalModules', () => {
     expect(console.info).toHaveBeenCalledTimes(2);
     expect(console.info.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
-        "the Node.js bundle for some-module finished saving, attempting to load",
+        "the Node.js bundle for %s finished saving, attempting to load",
+        "some-module",
       ]
     `);
   });
@@ -991,7 +994,8 @@ describe('watchLocalModules', () => {
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
-        "module \\"other-module\\" not in the module map, make sure to serve-module first",
+        "module \\"%s\\" not in the module map, make sure to serve-module first",
+        "other-module",
       ]
     `);
 

--- a/__tests__/server/utils/watchLocalModules.spec.js
+++ b/__tests__/server/utils/watchLocalModules.spec.js
@@ -216,7 +216,7 @@ jest.mock('fs', () => {
       }
 
       const printout = traverser('', mockedFilesystem);
-      console.log(printout);
+      console.info(printout);
       return mock;
     },
   };
@@ -311,7 +311,7 @@ jest.mock('holocron/loadModule.node', () => jest.fn(() => Promise.resolve(() => 
 
 jest.spyOn(console, 'error').mockImplementation(() => {});
 jest.spyOn(console, 'warn').mockImplementation(() => {});
-jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'info').mockImplementation(() => {});
 
 describe('watchLocalModules', () => {
   let origOneAppDevCDNPort;
@@ -363,19 +363,19 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello");');
 
     // initiate watching
     watchLocalModules();
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -386,12 +386,12 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello again");');
     loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
 
     // run the third change poll, which should see the filesystem changes
@@ -401,7 +401,7 @@ describe('watchLocalModules', () => {
     // first the changeWatcher is queued to run again
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(4);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the writesFinishWatcher poll
     await setTimeout.mock.calls[3][0]();
@@ -409,7 +409,7 @@ describe('watchLocalModules', () => {
     expect(setImmediate).toHaveBeenCalledTimes(2);
     expect(setTimeout).toHaveBeenCalledTimes(4);
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the change handler
     await setImmediate.mock.calls[1][0](setImmediate.mock.calls[1][1]);
@@ -419,8 +419,8 @@ describe('watchLocalModules', () => {
 
     expect(loadModule).toHaveBeenCalledTimes(1);
     expect(getModules().get(moduleName)).toBe(updatedModule);
-    expect(console.log).toHaveBeenCalledTimes(2);
-    expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(console.info).toHaveBeenCalledTimes(2);
+    expect(console.info.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "the Node.js bundle for some-module finished saving, attempting to load",
       ]
@@ -457,19 +457,19 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello");');
 
     // initiate watching
     watchLocalModules();
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -480,12 +480,12 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello again");');
     loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
 
     // run the third change poll, which should see the filesystem changes
@@ -495,7 +495,7 @@ describe('watchLocalModules', () => {
     // first the changeWatcher is queued to run again
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(4);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the writesFinishWatcher poll
     await setTimeout.mock.calls[3][0]();
@@ -503,7 +503,7 @@ describe('watchLocalModules', () => {
     expect(setImmediate).toHaveBeenCalledTimes(2);
     expect(setTimeout).toHaveBeenCalledTimes(4);
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the change handler
     await setImmediate.mock.calls[1][0](setImmediate.mock.calls[1][1]);
@@ -513,8 +513,8 @@ describe('watchLocalModules', () => {
 
     expect(loadModule).toHaveBeenCalledTimes(1);
     expect(getModules().get(moduleName)).toBe(updatedModule);
-    expect(console.log).toHaveBeenCalledTimes(2);
-    expect(console.log.mock.calls[1]).toMatchInlineSnapshot(`
+    expect(console.info).toHaveBeenCalledTimes(2);
+    expect(console.info.mock.calls[1]).toMatchInlineSnapshot(`
       Array [
         "finished reloading some-module",
       ]
@@ -551,19 +551,19 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello");');
 
     // initiate watching
     watchLocalModules();
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -574,12 +574,12 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello again");');
     loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
 
     // run the third change poll, which should see the filesystem changes
@@ -589,7 +589,7 @@ describe('watchLocalModules', () => {
     // first the changeWatcher is queued to run again
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(4);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the writesFinishWatcher poll
     await setTimeout.mock.calls[3][0]();
@@ -597,7 +597,7 @@ describe('watchLocalModules', () => {
     expect(setImmediate).toHaveBeenCalledTimes(2);
     expect(setTimeout).toHaveBeenCalledTimes(4);
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the change handler
     await setImmediate.mock.calls[1][0](setImmediate.mock.calls[1][1]);
@@ -659,19 +659,19 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello");');
 
     // initiate watching
     watchLocalModules();
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -682,12 +682,12 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello again");');
     loadModule.mockImplementationOnce(() => Promise.reject(new Error('sample-module startup error')));
 
     // run the third change poll, which should see the filesystem changes
@@ -697,7 +697,7 @@ describe('watchLocalModules', () => {
     // first the changeWatcher is queued to run again
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(4);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the writesFinishWatcher poll
     await setTimeout.mock.calls[3][0]();
@@ -705,7 +705,7 @@ describe('watchLocalModules', () => {
     expect(setImmediate).toHaveBeenCalledTimes(2);
     expect(setTimeout).toHaveBeenCalledTimes(4);
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the change handler
     await setImmediate.mock.calls[1][0](setImmediate.mock.calls[1][1]);
@@ -747,19 +747,19 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello");');
 
     // initiate watching
     watchLocalModules();
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -770,12 +770,12 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("he');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("he');
     loadModule.mockImplementation(() => Promise.reject(new Error('sample-module startup error')));
 
     // run the third change poll, which should see the filesystem changes
@@ -786,7 +786,7 @@ describe('watchLocalModules', () => {
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(4);
 
-    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello again");');
     loadModule.mockClear().mockReturnValue(Promise.resolve(updatedModule));
 
     // run the writesFinishWatcher poll after the writing finishes
@@ -850,12 +850,12 @@ describe('watchLocalModules', () => {
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -866,12 +866,12 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello again");');
     loadModule.mockReturnValueOnce(Promise.resolve(updatedModule));
 
     // run the third change poll, which should see the filesystem changes
@@ -881,7 +881,7 @@ describe('watchLocalModules', () => {
     // first the changeWatcher is queued to run again
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(4);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the writesFinishWatcher poll
     await setTimeout.mock.calls[3][0]();
@@ -889,7 +889,7 @@ describe('watchLocalModules', () => {
     expect(setImmediate).toHaveBeenCalledTimes(2);
     expect(setTimeout).toHaveBeenCalledTimes(4);
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the change handler
     await setImmediate.mock.calls[1][0](setImmediate.mock.calls[1][1]);
@@ -899,8 +899,8 @@ describe('watchLocalModules', () => {
 
     expect(loadModule).toHaveBeenCalledTimes(1);
     expect(getModules().get(moduleName)).toBe(updatedModule);
-    expect(console.log).toHaveBeenCalledTimes(2);
-    expect(console.log.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(console.info).toHaveBeenCalledTimes(2);
+    expect(console.info.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         "the Node.js bundle for some-module finished saving, attempting to load",
       ]
@@ -937,7 +937,7 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', 'other-module', '1.2.3'), { parents: true })
-      .writeFile(path.resolve('static/modules', 'other-module', '1.2.3', `${'other-module'}.node.js`), 'console.log("hello");');
+      .writeFile(path.resolve('static/modules', 'other-module', '1.2.3', `${'other-module'}.node.js`), 'console.info("hello");');
 
     loadModule.mockReturnValue(Promise.resolve(updatedModule));
 
@@ -946,12 +946,12 @@ describe('watchLocalModules', () => {
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -962,12 +962,12 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', 'other-module', '1.2.3'), { parents: true })
-      .writeFile(path.resolve('static/modules', 'other-module', '1.2.3', `${'other-module'}.node.js`), 'console.log("hello");');
+      .writeFile(path.resolve('static/modules', 'other-module', '1.2.3', `${'other-module'}.node.js`), 'console.info("hello");');
 
     // run the third change poll, which should see the filesystem changes
     await setTimeout.mock.calls[1][0]();
@@ -999,7 +999,7 @@ describe('watchLocalModules', () => {
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello again");');
 
     // run the changeWatcher poll
     await setTimeout.mock.calls[2][0]();
@@ -1059,19 +1059,19 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello");');
 
     // initiate watching
     watchLocalModules();
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -1082,12 +1082,12 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
       .delete(path.resolve('static/modules', moduleName))
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello again");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello again");');
     loadModule.mockImplementation(() => Promise.reject(new Error('sample-module startup error')));
 
     // run the third change poll, which should see the filesystem changes
@@ -1138,21 +1138,21 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello Node.js");')
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.browser.js`), 'console.log("hello Browser");')
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.legacy.browser.js`), 'console.log("hello previous spec Browser");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello Node.js");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.browser.js`), 'console.info("hello Browser");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.legacy.browser.js`), 'console.info("hello previous spec Browser");');
 
     // initiate watching
     watchLocalModules();
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -1163,11 +1163,11 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.browser.js`), 'console.log("hello again Browser");')
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.legacy.browser.js`), 'console.log("hello again previous spec Browser");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.browser.js`), 'console.info("hello again Browser");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.legacy.browser.js`), 'console.info("hello again previous spec Browser");');
     loadModule.mockImplementation(() => Promise.reject(new Error('sample-module startup error')));
 
     // run the third change poll, which should see but ignore the filesystem changes
@@ -1178,7 +1178,7 @@ describe('watchLocalModules', () => {
 
     expect(loadModule).not.toHaveBeenCalled();
 
-    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello Node.js");');
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello Node.js");');
     loadModule.mockClear().mockReturnValue(Promise.resolve(updatedModule));
 
     // run the fourth change poll, which should see the filesystem changes
@@ -1188,7 +1188,7 @@ describe('watchLocalModules', () => {
     // first the changeWatcher is queued to run again
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(5);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the writesFinishWatcher poll
     await setTimeout.mock.calls[4][0]();
@@ -1196,7 +1196,7 @@ describe('watchLocalModules', () => {
     expect(setImmediate).toHaveBeenCalledTimes(2);
     expect(setTimeout).toHaveBeenCalledTimes(5);
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the change handler
     await setImmediate.mock.calls[1][0](setImmediate.mock.calls[1][1]);
@@ -1237,20 +1237,20 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");')
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, 'vendors.node.js'), 'console.log("hi");');
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, 'vendors.node.js'), 'console.info("hi");');
 
     // initiate watching
     watchLocalModules();
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -1261,9 +1261,9 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
-    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, 'vendors.node.js'), 'console.log("hi there");');
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, 'vendors.node.js'), 'console.info("hi there");');
     loadModule.mockImplementation(() => Promise.reject(new Error('sample-module startup error')));
 
     // run the third change poll, which should see but ignore the filesystem changes
@@ -1274,7 +1274,7 @@ describe('watchLocalModules', () => {
 
     expect(loadModule).not.toHaveBeenCalled();
 
-    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello Node.js");');
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello Node.js");');
     loadModule.mockClear().mockReturnValue(Promise.resolve(updatedModule));
 
     // run the fourth change poll, which should see the filesystem changes
@@ -1284,7 +1284,7 @@ describe('watchLocalModules', () => {
     // first the changeWatcher is queued to run again
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(5);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the writesFinishWatcher poll
     await setTimeout.mock.calls[4][0]();
@@ -1292,7 +1292,7 @@ describe('watchLocalModules', () => {
     expect(setImmediate).toHaveBeenCalledTimes(2);
     expect(setTimeout).toHaveBeenCalledTimes(5);
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the change handler
     await setImmediate.mock.calls[1][0](setImmediate.mock.calls[1][1]);
@@ -1333,7 +1333,7 @@ describe('watchLocalModules', () => {
     resetModuleRegistry(modules, moduleMap);
     fs.mock
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion), { parents: true })
-      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello");')
+      .writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello");')
       .mkdir(path.resolve('static/modules', moduleName, moduleVersion, 'assets'), { parents: true })
       .writeFile(path.resolve('static/modules', moduleName, moduleVersion, 'assets', 'image.png'), 'binary stuff');
 
@@ -1342,12 +1342,12 @@ describe('watchLocalModules', () => {
 
     expect(setTimeout).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the first change poll
     await setImmediate.mock.calls[0][0]();
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
     expect(setImmediate).toHaveBeenCalledTimes(1);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
@@ -1358,7 +1358,7 @@ describe('watchLocalModules', () => {
     expect(setTimeout).toHaveBeenCalledTimes(2);
 
     expect(getModules().get(moduleName)).toBe(originalModule);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, 'assets', 'image.png'), 'other binary stuff');
     loadModule.mockImplementation(() => Promise.reject(new Error('sample-module startup error')));
@@ -1371,7 +1371,7 @@ describe('watchLocalModules', () => {
 
     expect(loadModule).not.toHaveBeenCalled();
 
-    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.log("hello Node.js");');
+    fs.mock.writeFile(path.resolve('static/modules', moduleName, moduleVersion, `${moduleName}.node.js`), 'console.info("hello Node.js");');
     loadModule.mockClear().mockReturnValue(Promise.resolve(updatedModule));
 
     // run the fourth change poll, which should see the filesystem changes
@@ -1381,7 +1381,7 @@ describe('watchLocalModules', () => {
     // first the changeWatcher is queued to run again
     // then the writesFinishWatcher is queued
     expect(setTimeout).toHaveBeenCalledTimes(5);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the writesFinishWatcher poll
     await setTimeout.mock.calls[4][0]();
@@ -1389,7 +1389,7 @@ describe('watchLocalModules', () => {
     expect(setImmediate).toHaveBeenCalledTimes(2);
     expect(setTimeout).toHaveBeenCalledTimes(5);
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(console.info).not.toHaveBeenCalled();
 
     // run the change handler
     await setImmediate.mock.calls[1][0](setImmediate.mock.calls[1][1]);

--- a/src/server/utils/watchLocalModules.js
+++ b/src/server/utils/watchLocalModules.js
@@ -17,8 +17,10 @@
 // This file is only used in development so importing devDeps is not an issue
 /* eslint "import/no-extraneous-dependencies": ["error", {"devDependencies": true}] */
 
-import path from 'path';
+import path from 'node:path';
+import fs from 'node:fs/promises';
 import chokidar from 'chokidar';
+import globSync from 'glob';
 import loadModule from 'holocron/loadModule.node';
 import {
   getModules,
@@ -27,56 +29,128 @@ import {
   addHigherOrderComponent,
 } from 'holocron/moduleRegistry';
 import onModuleLoad from './onModuleLoad';
+import { promisify } from 'node:util';
+
+const glob = promisify(globSync);
+
+async function changeHandler(changedPath) {
+  console.log('watcher Δ', changedPath);
+  if (!changedPath.endsWith('.node.js')) return;
+
+  // I had apprehension of this manual manipulation
+  // but from what I can tell a file or directory with '/' in the name is not valid
+  // Linux: https://stackoverflow.com/q/9847288
+  // macOS: '/' from Finder is translated to ':'
+  // Windows: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+  const parts = changedPath.split(path.sep);
+  if (parts.length < 3) {
+    console.warn(`detected a change in module static resources at "${changedPath}" but unable to reload it in the running server`);
+    return;
+  }
+
+  const [moduleName] = parts;
+  const moduleMap = getModuleMap();
+  const moduleMapEntry = moduleMap.getIn(['modules', moduleName]);
+
+  if (!moduleMapEntry) {
+    console.warn(`module "${moduleName}" not in the module map, make sure to serve-module first`);
+    return;
+  }
+
+  if (new URL(moduleMapEntry.getIn(['node', 'url'])).pathname !== `/static/modules/${changedPath}`) {
+    // not a Holocron module entry bundle (e.g. might be using webpack chunking)
+    // console.warn('not a Holocron entry!', changedPath);
+    return;
+  }
+
+  console.log(`the Node.js bundle for ${moduleName} finished saving, attempting to load`);
+
+  let newModule;
+  try {
+    // FIXME: this leads to a race condition later in editing the module map
+    newModule = addHigherOrderComponent(await loadModule(
+      moduleName,
+      moduleMapEntry.toJS(),
+      onModuleLoad
+    ));
+  } catch (error) {
+    // loadModule already logs the error and then re-throws
+    // logging again just adds noise for the developer
+    return;
+  }
+
+  const newModules = getModules().set(moduleName, newModule);
+  resetModuleRegistry(newModules, moduleMap);
+  console.log(`finished reloading ${moduleName}`);
+}
 
 export default function watchLocalModules() {
   const staticsDirectoryPath = path.resolve(__dirname, '../../../static');
   const moduleDirectory = path.join(staticsDirectoryPath, 'modules');
 
-  chokidar
-    .watch('*/*/*.node.js', {
-      awaitWriteFinish: true,
-      cwd: moduleDirectory,
-    })
-    .on('change', async (changedPath) => {
-      if (!changedPath.endsWith('.node.js')) return;
+  // chokidar
+  //   .watch('*/*/*.node.js', {
+  //     awaitWriteFinish: true,
+  //     cwd: moduleDirectory,
+  //     depth: 3,
+  //     // usePolling: true,
+  //   })
+  //   .on('change', changeHandler);
 
-      // I had apprehension of this manual manipulation
-      // but from what I can tell a file or directory with '/' in the name is not valid
-      // Linux: https://stackoverflow.com/q/9847288
-      // macOS: '/' from Finder is translated to ':'
-      // Windows: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
-      const parts = changedPath.split(path.sep);
-      if (parts.length < 3) {
-        console.warn(`detected a change in module static resources at "${changedPath}" but unable to reload it in the running server`);
-        return;
-      }
-
-      const [moduleName] = parts;
-      const moduleMap = getModuleMap();
-      const moduleMapEntry = moduleMap.getIn(['modules', moduleName]);
-
-      if (new URL(moduleMapEntry.getIn(['node', 'url'])).pathname !== `/static/modules/${changedPath}`) {
-        // not a Holocron module entry bundle (e.g. might be using webpack chunking)
-        return;
-      }
-
-      console.log(`the Node.js bundle for ${moduleName} finished saving, attempting to load`);
-
-      let newModule;
-      try {
-        newModule = addHigherOrderComponent(await loadModule(
-          moduleName,
-          moduleMapEntry.toJS(),
-          onModuleLoad
-        ));
-      } catch (error) {
-        // loadModule already logs the error and then re-throws
-        // logging again just adds noise for the developer
-        return;
-      }
-
-      const newModules = getModules().set(moduleName, newModule);
-      resetModuleRegistry(newModules, moduleMap);
-      console.log(`finished reloading ${moduleName}`);
+  var previousStats;
+  async function looper() {
+    console.time('glob');
+    const holocronEntrypoints = (await glob('*/*/*.node.js', { cwd: moduleDirectory }))
+    .filter(p => { const parts = p.split('/'); return parts[0] === path.basename(parts[2], '.node.js') })
+    .sort();
+    // .map(p => path.join(moduleDirectory, p));
+    console.timeEnd('glob');
+    
+    const currentStats = new Map();
+    const statsToWait = [];
+    holocronEntrypoints.forEach((holocronEntrypoint) => {
+      console.time(holocronEntrypoint);
+      // statsToWait.push(fs.stat(path.join(moduleDirectory, holocronEntrypoint)).then(stat => currentStats.set(holocronEntrypoint, stat)))
+      statsToWait.push(fs.stat(path.join(moduleDirectory, holocronEntrypoint)).then(stat => {
+        console.timeEnd(holocronEntrypoint);
+        currentStats.set(holocronEntrypoint, stat)
+      }))
     });
+    await Promise.allSettled(statsToWait);
+
+    if (!previousStats) {
+      previousStats = currentStats;
+      setTimeout(looper, 2e3);
+      return;
+    }
+
+    const changes = [];
+    for (const [holocronEntrypoint, currentStat] of currentStats.entries()) {
+      if (!previousStats.has(holocronEntrypoint)) {
+        // console.log('looper, new entry', holocronEntrypoint);
+        changes.push(holocronEntrypoint);
+        continue;
+      }
+      const previousStat = previousStats.get(holocronEntrypoint);
+      // console.log('looper, change?', holocronEntrypoint, `${currentStat.mtimeMs} !==? ${previousStat.mtimeMs} || ${currentStat.size} !==? ${previousStat.size}`);
+      if (currentStat.mtimeMs !== previousStat.mtimeMs || currentStat.size !== previousStat.size) {
+        changes.push(holocronEntrypoint);
+        continue;
+      }
+      continue;
+    }
+
+    previousStats = currentStats;
+    setTimeout(looper, 3e3).unref();
+    if (changes.length === 0) {
+      return;
+    }
+    console.log('looper, changes', changes);
+
+    // FIXME: wait for the writer to finish editing the file first
+    for await (const holocronEntrypoint of changes) {
+      await changeHandler(holocronEntrypoint);
+    }
+  }
+  setImmediate(looper);
 }

--- a/src/server/utils/watchLocalModules.js
+++ b/src/server/utils/watchLocalModules.js
@@ -57,11 +57,11 @@ async function changeHandler(changedPath) {
   const moduleMapEntry = moduleMap.getIn(['modules', moduleName]);
 
   if (!moduleMapEntry) {
-    console.warn(`module "${moduleName}" not in the module map, make sure to serve-module first`);
+    console.warn('module "%s" not in the module map, make sure to serve-module first', moduleName);
     return;
   }
 
-  console.log(`the Node.js bundle for ${moduleName} finished saving, attempting to load`);
+  console.info('the Node.js bundle for %s finished saving, attempting to load', moduleName);
 
   let newModule;
   try {
@@ -80,7 +80,7 @@ async function changeHandler(changedPath) {
 
   const newModules = getModules().set(moduleName, newModule);
   resetModuleRegistry(newModules, moduleMap);
-  console.log(`finished reloading ${moduleName}`);
+  console.info('finished reloading %s', moduleName);
 }
 
 export default function watchLocalModules() {

--- a/src/server/utils/watchLocalModules.js
+++ b/src/server/utils/watchLocalModules.js
@@ -17,7 +17,6 @@
 // This file is only used in development so importing devDeps is not an issue
 /* eslint "import/no-extraneous-dependencies": ["error", {"devDependencies": true}] */
 
-import fs from 'fs';
 import path from 'path';
 import chokidar from 'chokidar';
 import loadModule from 'holocron/loadModule.node';
@@ -27,44 +26,57 @@ import {
   resetModuleRegistry,
   addHigherOrderComponent,
 } from 'holocron/moduleRegistry';
-import { address } from 'ip';
 import onModuleLoad from './onModuleLoad';
-
-const ip = address();
 
 export default function watchLocalModules() {
   const staticsDirectoryPath = path.resolve(__dirname, '../../../static');
-  const moduleDirectory = path.resolve(staticsDirectoryPath, 'modules');
-  const moduleMapPath = path.resolve(staticsDirectoryPath, 'module-map.json');
-  const watcher = chokidar.watch(moduleDirectory, { awaitWriteFinish: true });
+  const moduleDirectory = path.join(staticsDirectoryPath, 'modules');
 
-  watcher.on('change', async (changedPath) => {
-    try {
+  chokidar
+    .watch('*/*/*.node.js', {
+      awaitWriteFinish: true,
+      cwd: moduleDirectory,
+    })
+    .on('change', async (changedPath) => {
       if (!changedPath.endsWith('.node.js')) return;
 
-      const match = changedPath.slice(moduleDirectory.length).match(/\/([^/]+)\/([^/]+)/);
-      if (!match) return;
-      const [, moduleNameChangeDetectedIn] = match;
+      // I had apprehension of this manual manipulation
+      // but from what I can tell a file or directory with '/' in the name is not valid
+      // Linux: https://stackoverflow.com/q/9847288
+      // macOS: '/' from Finder is translated to ':'
+      // Windows: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+      const parts = changedPath.split(path.sep);
+      if (parts.length < 3) {
+        console.warn(`detected a change in module static resources at "${changedPath}" but unable to reload it in the running server`);
+        return;
+      }
 
-      const moduleMap = JSON.parse(fs.readFileSync(moduleMapPath, 'utf8'));
+      const [moduleName] = parts;
+      const moduleMap = getModuleMap();
+      const moduleMapEntry = moduleMap.getIn(['modules', moduleName]);
 
-      const moduleData = moduleMap.modules[moduleNameChangeDetectedIn];
-      const oneAppDevCdnAddress = `http://${ip}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT || 3001}`;
+      if (new URL(moduleMapEntry.getIn(['node', 'url'])).pathname !== `/static/modules/${changedPath}`) {
+        // not a Holocron module entry bundle (e.g. might be using webpack chunking)
+        return;
+      }
 
-      moduleData.browser.url = moduleData.browser.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
-      moduleData.legacyBrowser.url = moduleData.legacyBrowser.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
-      moduleData.node.url = moduleData.node.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
+      console.log(`the Node.js bundle for ${moduleName} finished saving, attempting to load`);
 
-      const module = addHigherOrderComponent(await loadModule(
-        moduleNameChangeDetectedIn,
-        moduleData,
-        onModuleLoad
-      ));
+      let newModule;
+      try {
+        newModule = addHigherOrderComponent(await loadModule(
+          moduleName,
+          moduleMapEntry.toJS(),
+          onModuleLoad
+        ));
+      } catch (error) {
+        // loadModule already logs the error and then re-throws
+        // logging again just adds noise for the developer
+        return;
+      }
 
-      const modules = getModules().set(moduleNameChangeDetectedIn, module);
-      resetModuleRegistry(modules, getModuleMap());
-    } catch (error) {
-      console.error(error);
-    }
-  });
+      const newModules = getModules().set(moduleName, newModule);
+      resetModuleRegistry(newModules, moduleMap);
+      console.log(`finished reloading ${moduleName}`);
+    });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During development use filesystem polling to detect modules being built and then reload them in the running server. This increases the filesystem and CPU usage, but is much more reliable.

This also adds some log entries for the user to know when a module was reloaded, removing guesswork.

Some unnecessary disk reads (module map) were removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users are hitting development scenarios where new builds of modules are not detected and then not reloaded in the running server. The [limitations of the Node.js built-in API](https://nodejs.org/docs/latest-v18.x/api/fs.html#fswatchfilename-options-listener) are important, but are smoothed over by [chokidar](https://www.npmjs.com/package/chokidar). However, even chokidar is not accurately emiting events, sometimes due to superseding situations like the modules being docker volume mounts, e.g. https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've both 
* `$ npm serve-module some-module` and run the server
* built the image and provided the digest to [@americanexpress/one-app-runner](https://github.com/americanexpress/one-app-cli/tree/main/packages/one-app-runner) in a module 

Before these changes running on metal would occasionally miss the file writing finishing and not reload, and running in a docker container every change after the first build would be missed. After the changes in this PR I saw every write finish detected.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] These changes should be applied to a maintenance branch. (This is that PR, see #1370)
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
Increased confidence when changes are loaded, and end (or at the very least, greatly decrease) the users having to restart the one-app server to see server bundle changes loaded.