### PR TITLE
chore(scripts): remove postinstall and preinstall

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,5 +1,5 @@
 feature: ['feature/*', 'feat/*']
-fix: ['fix/*', 'bug/*']
+fix: ['fix/*', 'bug/*', 'bugfix/*']
 chore: chore/*
 documentation: docs/*
 refactor: refactor/*

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -14,7 +14,8 @@ jobs:
         env:
           NODE_ENV: development
         with:
-          build-script: "build:bundle"
+          build-script: "build:bundle:prod"
+          clean-script: "clean:build"
           pattern: "./build/**/*.js"
           strip-hash: \d+\.\d+\.\d+[-\S+]*\/
-          exclude: "{./build/**/i18n/*.js,./build/**/legacy/**,./build/**/tmp/**,**/*.map,**/node_modules/**}"
+          exclude: "{./build/**/i18n/*.js,./build/**/legacy/**,./build/**/tmp/**,**/node_modules/**}"

--- a/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
+++ b/.github/workflows/on-pr-and-trunk_one-app-unit-and-lint-tests.yml
@@ -30,9 +30,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - name: npm install
-        run: NODE_ENV=development npm ci
+        run: npm ci
         env:
+          NODE_ENV: development
           HUSKY: 0
+      - name: npm run build
+        run: npm run build
+        env:
+          NODE_ENV: production
       - name: npm unit test
         run:  npm run test:unit
       - name: npm lint test

--- a/.github/workflows/on-pr_dangerJS.yml
+++ b/.github/workflows/on-pr_dangerJS.yml
@@ -16,10 +16,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-
     - name: npm install
-      run: NODE_ENV=development npm ci
+      run: npm ci
       env:
-          HUSKY: 0
+        NODE_ENV: development
+        HUSKY: 0
     - name: Danger
-      run: NODE_ENV=production npm run test:danger
+      run: npm run test:danger
       env:
+        NODE_ENV: production
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-pr_one-app-integration-tests.yml
+++ b/.github/workflows/on-pr_one-app-integration-tests.yml
@@ -16,8 +16,9 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: npm install
-        run: NODE_ENV=development npm ci
+        run: npm ci
         env:
+          NODE_ENV: development
           HUSKY: 0
       - name: Build docker image
         run: docker build -t one-app:at-test . --build-arg USER=root --build-arg VERSION=$(cat .nvmrc)

--- a/.github/workflows/release-step-1_manual_create-release-pr.yml
+++ b/.github/workflows/release-step-1_manual_create-release-pr.yml
@@ -32,13 +32,14 @@ jobs:
       - name: One App release
         id: vars
         run: |
-          NODE_ENV=development npm ci
+          npm ci
           git config --local user.email "one.amex@aexp.com"
           git config --local user.name "OneAmexBot"
           npm run release
           git add .
           git commit -m "docs(changelog): update"
         env:
+          NODE_ENV: development
           HUSKY: 0
       - name: Create release pull request
         uses: peter-evans/create-pull-request@v6

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "npm": ">=8"
   },
   "scripts": {
-    "preinstall": "npx check-engines@1",
     "rimraf": "node -e \"process.argv.slice(1).forEach(path => require('node:fs').rmSync(path, { recursive: true, force: true }));\" --",
     "clean": "npm run clean:build && npm run clean:test",
     "clean:build": "npm run rimraf dist lib build lastBuild.json stats.json",
     "clean:test": "npm run rimraf test-results",
     "prebuild": "npm run clean:build",
+    "build:bundle:prod": "cross-env NODE_ENV=production npm run build:bundle",
     "build:bundle": "cross-env \"NODE_OPTIONS=--max-old-space-size=4096 --openssl-legacy-provider\" bundle-one-app",
     "build:server": "cross-env BABEL_ENV=server babel src --out-dir lib --ignore \"**/__mocks__\"",
     "build:service-workers": "node scripts/build-service-workers.js",
@@ -42,7 +42,6 @@
     "drop-module": "drop-module",
     "set-middleware": "set-middleware",
     "set-dev-endpoints": "node scripts/set-dev-endpoints.js",
-    "postinstall": "npm run build",
     "release:standard-version": "standard-version -n",
     "release:changelog": "echo \"$(head -3 CHANGELOG.md)\n\n$(node_modules/.bin/conventional-changelog -p angular)\n\n$(tail -n +4 CHANGELOG.md)\" > CHANGELOG.md",
     "release": "npm run release:standard-version && npm run release:changelog",


### PR DESCRIPTION
## Description

> Note: **Build Size - gzipped / build (pull_request)** is _expected_ to fail for this PR because the script does not exist in main

Remove `postinstall` and `preinstall` scripts

Also fixed an issue with the bundle-size workflow which was validating development asset size instead of production asset size. I had to add a new script for it since you can't define NODE_ENV separately for install and build scripts in this workflow.

Minor refactor in how NODE_ENV is set in workflows.

## Motivation and Context

`presinstall` runs `check-engines` which is not needed since we have `engine-strict=true` in `.npmrc`. That enforces this without an additional dependency.

`postinstall` runs `npm run build` which is not super useful as we don't always need a build on every install, and often we need a production build, so we have to run it again since `npm install`/`npm ci` needs to be run with `NODE_ENV` as `development`.

I added `npm run build` as a step in the unit/lint workflow to continue validating that build succeeds.

## How Has This Been Tested?

Worfklows running on this PR.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
<!--- Please describe how your changes impacts developers using One App. -->
 N/A