### PR TITLE
fix(watchLocalModules): fix missing baseUrl

### DIFF
--- a/__tests__/server/utils/watchLocalModules.spec.js
+++ b/__tests__/server/utils/watchLocalModules.spec.js
@@ -25,6 +25,7 @@ import {
 } from 'holocron/moduleRegistry';
 import watchLocalModules from '../../../src/server/utils/watchLocalModules';
 import { getIp } from '../../../src/server/utils/getIP';
+import addBaseUrlToModuleMap from '../../../src/server/utils/addBaseUrlToModuleMap';
 
 const ip = getIp();
 
@@ -112,7 +113,7 @@ describe('watchLocalModules', () => {
     await changeListener(modulePath);
     expect(loadModule).toHaveBeenCalledWith(
       moduleName,
-      moduleMapSample.modules[moduleName],
+      addBaseUrlToModuleMap(moduleMapSample).modules[moduleName],
       require('../../../src/server/utils/onModuleLoad').default
     );
     expect(getModules().get(moduleName)).toBe(updatedModule);
@@ -153,7 +154,7 @@ describe('watchLocalModules', () => {
     await changeListener(modulePath);
     expect(loadModule).toHaveBeenCalledWith(
       moduleName,
-      moduleMapSample.modules[moduleName],
+      addBaseUrlToModuleMap(moduleMapSample).modules[moduleName],
       require('../../../src/server/utils/onModuleLoad').default
     );
     expect(getModules().get(moduleName)).toBe(originalModule);
@@ -234,7 +235,7 @@ describe('watchLocalModules', () => {
     await changeListener(modulePath);
     expect(loadModule).toHaveBeenCalledWith(
       moduleName,
-      updatedModuleMapSample.modules[moduleName],
+      addBaseUrlToModuleMap(updatedModuleMapSample).modules[moduleName],
       require('../../../src/server/utils/onModuleLoad').default
     );
     expect(getModules().get(moduleName)).toBe(updatedModule);

--- a/src/server/utils/watchLocalModules.js
+++ b/src/server/utils/watchLocalModules.js
@@ -26,6 +26,7 @@ import {
 } from 'holocron/moduleRegistry';
 import { getIp } from './getIP';
 import onModuleLoad from './onModuleLoad';
+import addBaseUrlToModuleMap from './addBaseUrlToModuleMap';
 
 export default function watchLocalModules() {
   const staticsDirectoryPath = path.resolve(__dirname, '../../../static');
@@ -43,12 +44,13 @@ export default function watchLocalModules() {
 
       const moduleMap = JSON.parse(fs.readFileSync(moduleMapPath, 'utf8'));
 
-      const moduleData = moduleMap.modules[moduleNameChangeDetectedIn];
+      const moduleData = addBaseUrlToModuleMap(moduleMap).modules[moduleNameChangeDetectedIn];
       const oneAppDevCdnAddress = `http://${getIp()}:${process.env.HTTP_ONE_APP_DEV_CDN_PORT || 3001}`;
 
       moduleData.browser.url = moduleData.browser.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
       moduleData.legacyBrowser.url = moduleData.legacyBrowser.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
       moduleData.node.url = moduleData.node.url.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
+      moduleData.baseUrl = moduleData.baseUrl.replace('[one-app-dev-cdn-url]', oneAppDevCdnAddress);
 
       const module = addHigherOrderComponent(await loadModule(
         moduleNameChangeDetectedIn,


### PR DESCRIPTION
## Description
This fixes users seeing the following log when re-building locally served modules running the dev server:
```Encountered error fetching module at undefinedmodule-config.json: Only absolute URLs are supported```

## Motivation and Context
This bug means the module-config.json will never load, and the users sees an error they have no way of understanding

## How Has This Been Tested?
running agains reproduction case
unit tests

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
- [ ] Security update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] Performance tests should be ran against the server prior to merging.
- [ ] This change impacts caching for client browsers.
- [ ] This change impacts HTTP headers.
- [ ] This change adds additional environment variable requirements for One App users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using One App?
No more confusing log